### PR TITLE
Allow scope to be a tuple to bring api in line with Goth

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -194,8 +194,9 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   defp validate_option(:token_generator, value),
     do: validation_error(:token_generator, "a tuple {Mod, Fun, Args}", value)
 
-  defp validate_option(:scope, value) when not is_binary(value) or value == "",
-    do: validation_error(:scope, "a non empty string", value)
+  defp validate_option(:scope, value)
+       when not (is_binary(value) or is_tuple(value)) or (value == "" or value == {}),
+       do: validation_error(:scope, "a non empty string or tuple", value)
 
   defp validate_option(:subscription, value) when not is_binary(value) or value == "",
     do: validation_error(:subscription, "a non empty string", value)

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -132,7 +132,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
       assert message == "expected :max_number_of_messages to be a positive integer, got: :an_atom"
     end
 
-    test ":scope should be a string" do
+    test ":scope should be a string or tuple" do
       opts = [subscription: "projects/foo/subscriptions/bar"]
 
       {:ok, result} = opts |> Keyword.put(:scope, "https://example.com") |> GoogleApiClient.init()
@@ -141,11 +141,22 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
 
       {:error, message} = opts |> Keyword.put(:scope, :an_atom) |> GoogleApiClient.init()
 
-      assert message == "expected :scope to be a non empty string, got: :an_atom"
+      assert message == "expected :scope to be a non empty string or tuple, got: :an_atom"
 
       {:error, message} = opts |> Keyword.put(:scope, 1) |> GoogleApiClient.init()
 
-      assert message == "expected :scope to be a non empty string, got: 1"
+      assert message == "expected :scope to be a non empty string or tuple, got: 1"
+
+      {:error, message} = opts |> Keyword.put(:scope, {}) |> GoogleApiClient.init()
+
+      assert message == "expected :scope to be a non empty string or tuple, got: {}"
+
+      {:ok, result} =
+        opts
+        |> Keyword.put(:scope, {"mail@example.com", "https://example.com"})
+        |> GoogleApiClient.init()
+
+      assert {_, _, [{"mail@example.com", "https://example.com"}]} = result.token_generator
     end
 
     test ":token_generator defaults to using Goth with default scope" do


### PR DESCRIPTION
Goth allows you to use a JSON file containing an array of service accounts. This way one application can connect to multiple google services / accounts.
To specify which account to use you call `Goth.Token.for_scope` with that client_email like this:

```
{:ok, token} = Goth.Token.for_scope({
    "account2@myproject.iam.gserviceaccount.com",
    "https://www.googleapis.com/auth/cloud-platform.read-only"})
```

This pull allows you to pass this tuple as scope from your BroadwayCloudPubSub configuration:

```
BroadwayCloudPubSub.Producer,
  [
    subscription: "projects/my-project/subscriptions/my-subscription”,
    scope: {"my-account@myproject.iam.gserviceaccount.com", 
            "https://www.googleapis.com/auth/pubsub"}
  ] 
```
