### PR TITLE
Remove sensitive details from error log messages

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -136,18 +136,36 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
   defp handle_response({:ok, _}, _), do: :ok
 
   defp handle_response({:error, reason}, :receive_messages) do
-    Logger.error("Unable to fetch events from Cloud Pub/Sub. Reason: #{inspect(reason)}")
+    Logger.error("Unable to fetch events from Cloud Pub/Sub. Reason: #{inspect_error(reason)}")
     []
   end
 
   defp handle_response({:error, reason}, :acknowledge) do
-    Logger.error("Unable to acknowledge messages with Cloud Pub/Sub, reason: #{inspect(reason)}")
+    Logger.error(
+      "Unable to acknowledge messages with Cloud Pub/Sub, reason: #{inspect_error(reason)}"
+    )
+
     :ok
   end
 
   defp handle_response({:error, reason}, :put_deadline) do
-    Logger.error("Unable to put new ack deadline with Cloud Pub/Sub, reason: #{inspect(reason)}")
+    Logger.error(
+      "Unable to put new ack deadline with Cloud Pub/Sub, reason: #{inspect_error(reason)}"
+    )
+
     :ok
+  end
+
+  defp inspect_error(%Tesla.Env{} = reason) do
+    # (__client__ includes the access token)
+    reason
+    |> Map.from_struct()
+    |> Map.delete(:__client__)
+    |> inspect()
+  end
+
+  defp inspect_error(reason) do
+    inspect(reason)
   end
 
   defp wrap_received_messages(received_messages, ack_builder) do

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -156,12 +156,12 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     :ok
   end
 
-  defp inspect_error(%Tesla.Env{} = reason) do
-    # (__client__ includes the access token)
-    reason
-    |> Map.from_struct()
-    |> Map.delete(:__client__)
-    |> inspect()
+  defp inspect_error(%Tesla.Env{} = env) do
+    """
+    \nRequest to #{inspect(env.url)} failed with status #{inspect(env.status)}, got:
+
+    #{inspect(env.body)}
+    """
   end
 
   defp inspect_error(reason) do


### PR DESCRIPTION
I saw the `Authorization` header inadvertently gets logged in errors (see screenshot below)

This PR drops the `:__client__` field from the `%Tesla.Env{}` before `inspect`-ing it, so that the `Authorization` header is no longer logged

<img width="1187" src="https://user-images.githubusercontent.com/446024/110701460-2f770d00-81bf-11eb-82bc-1b8e0739d1a9.png">