### PR TITLE
Use Tesla Retry Middleware

### DIFF
--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -57,6 +57,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
   defp should_retry?({:ok, _resp}), do: false
   defp should_retry?({:error, %{status: code}}) when code in @retry_codes, do: true
+  defp should_retry?({:error, _reason}), do: true
 
   @impl Client
   def prepare_to_connect(module, opts) do

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -83,7 +83,8 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
       retry =
         [should_retry: &should_retry?/1]
-        |> Keyword.merge(Keyword.get(opts, :retry, @retry_opts))
+        |> Keyword.merge(@retry_opts)
+        |> Keyword.merge(Keyword.get(opts, :retry, []))
 
       config = %{
         adapter: adapter,

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -28,9 +28,13 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
   @default_scope "https://www.googleapis.com/auth/pubsub"
 
+  @retry_codes [408, 500, 502, 503, 504, 522, 524]
+  @retry_opts [delay: 500, max_retries: 10]
+
   defp conn!(config, adapter_opts \\ []) do
     %{
       adapter: adapter,
+      retry: retry,
       connection_pool: connection_pool,
       token_generator: {mod, fun, args}
     } = config
@@ -39,15 +43,20 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
 
     adapter_opts = Keyword.put(adapter_opts, :pool, connection_pool)
 
+    middleware = [{Tesla.Middleware.Retry, retry}]
+
     token
     |> Connection.new()
-    |> override_tesla_adapter({adapter, adapter_opts})
+    |> override_tesla_client({adapter, adapter_opts}, middleware)
   end
 
-  defp override_tesla_adapter(client, adapter) do
-    %{adapter: adapter} = Tesla.client([], adapter)
-    %{client | adapter: adapter}
+  defp override_tesla_client(client, adapter, middleware) do
+    %{adapter: adapter, pre: pre} = Tesla.client(middleware, adapter)
+    %{client | adapter: adapter, pre: client.pre ++ pre}
   end
+
+  defp should_retry?({:ok, _resp}), do: false
+  defp should_retry?({:error, %{status: code}}) when code in @retry_codes, do: true
 
   @impl Client
   def prepare_to_connect(module, opts) do
@@ -71,8 +80,13 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
       adapter = Keyword.get(opts, :__internal_tesla_adapter__, Hackney)
       connection_pool = Keyword.get(opts, :__connection_pool__, :default)
 
+      retry =
+        [should_retry: &should_retry?/1]
+        |> Keyword.merge(Keyword.get(opts, :retry, @retry_opts))
+
       config = %{
         adapter: adapter,
+        retry: retry,
         connection_pool: connection_pool,
         subscription: subscription,
         token_generator: token_generator,

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -55,9 +55,9 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     %{client | adapter: adapter, pre: client.pre ++ pre}
   end
 
-  defp should_retry?({:ok, _resp}), do: false
   defp should_retry?({:error, %{status: code}}) when code in @retry_codes, do: true
   defp should_retry?({:error, _reason}), do: true
+  defp should_retry?(_other), do: false
 
   @impl Client
   def prepare_to_connect(module, opts) do

--- a/lib/broadway_cloud_pub_sub/google_api_client.ex
+++ b/lib/broadway_cloud_pub_sub/google_api_client.ex
@@ -55,7 +55,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClient do
     %{client | adapter: adapter, pre: client.pre ++ pre}
   end
 
-  defp should_retry?({:error, %{status: code}}) when code in @retry_codes, do: true
+  defp should_retry?({:error, %{status: code}}), do: code in @retry_codes
   defp should_retry?({:error, _reason}), do: true
   defp should_retry?(_other), do: false
 

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -31,14 +31,16 @@ defmodule BroadwayCloudPubSub.Producer do
     * `:pool_opts` - Optional. A set of additional options to override the
        default `:hackney_pool` configuration options.
 
-    * `:retry` - Optional. A request retrier configuration tuple`
+    * `:retry` - Optional. Configuration for retries.
+
       Any Google PubSub request with error response will be retried a few times before returning the error.
+
         - `:delay` - How long to wait (milliseconds) before retrying (positive integer, defaults to 500)
         - `:max_retries` - Maximum number of retries (non-negative integer, defaults to 10)
-        - `:should_retry` - Function to determine if request should be retried based on the response
-           default behaviour: Retries any error responses, and responses with status in [408, 500, 502, 503, 504, 522, 524]
+        - `:should_retry` - Function to determine if request should be retried based on the response.
+           Defaults to retrying all errors and responses with status 408, 500, 502, 503, 504, 522, and 524
 
-        Example: `[delay: 500, max_retries: 10]`
+      See `Tesla.Middleware.Retry` for more information.
 
   ## Acknowledger options
 

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -32,11 +32,11 @@ defmodule BroadwayCloudPubSub.Producer do
        default `:hackney_pool` configuration options.
 
     * `:retry` - Optional. A request retrier configuration tuple`
-      Any Google PubSub request with error response will be retried a few times before returning an error.
+      Any Google PubSub request with error response will be retried a few times before returning the error.
         - `:delay` - How long to wait (milliseconds) before retrying (positive integer, defaults to 500)
         - `:max_retries` - Maximum number of retries (non-negative integer, defaults to 10)
         - `:should_retry` - Function to determine if request should be retried based on the response
-           default: Retries any error responses, and responses with status in [408, 500, 502, 503, 504, 522, 524]
+           default behaviour: Retries any error responses, and responses with status in [408, 500, 502, 503, 504, 522, 524]
 
         Example: `[delay: 500, max_retries: 10]`
 

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -31,6 +31,15 @@ defmodule BroadwayCloudPubSub.Producer do
     * `:pool_opts` - Optional. A set of additional options to override the
        default `:hackney_pool` configuration options.
 
+    * `:retry` - Optional. A request retrier configuration tuple`
+      Any Google PubSub request with error response will be retried a few times before returning an error.
+        - `:delay` - How long to wait (milliseconds) before retrying (positive integer, defaults to 500)
+        - `:max_retries` - Maximum number of retries (non-negative integer, defaults to 10)
+        - `:should_retry` - Function to determine if request should be retried based on the response
+           default: Retries any error responses, and responses with status in [408, 500, 502, 503, 504, 522, 524]
+
+        Example: `[delay: 500, max_retries: 10]`
+
   ## Acknowledger options
 
   These options apply to `BroadwayCloudPubSub.GoogleApiClient` acknowledgement API:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BroadwayCloudPubSub.MixProject do
   use Mix.Project
 
-  @version "0.6.2"
+  @version "0.6.3"
   @description "A Google Cloud Pub/Sub connector for Broadway"
   @repo_url "https://github.com/dashbitco/broadway_cloud_pub_sub"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BroadwayCloudPubSub.MixProject do
   use Mix.Project
 
-  @version "0.6.3"
+  @version "0.6.2"
   @description "A Google Cloud Pub/Sub connector for Broadway"
   @repo_url "https://github.com/dashbitco/broadway_cloud_pub_sub"
 

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -272,8 +272,7 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
         %Tesla.Env{status: 403, body: %{}}
       end)
 
-      new_opts = Keyword.put(base_opts, :retry, delay: 10)
-      {:ok, opts} = GoogleApiClient.init(new_opts)
+      {:ok, opts} = GoogleApiClient.init(base_opts)
 
       assert capture_log(fn ->
                assert GoogleApiClient.receive_messages(10, & &1, opts) == []


### PR DESCRIPTION
Solving the same problem as: https://github.com/dashbitco/broadway_cloud_pub_sub/pull/56
but this time using Tesla Retry middleware as suggested in the issue discussion: https://github.com/dashbitco/broadway_cloud_pub_sub/issues/55

Decisions I made:

1. Only retry requests with status code = `[408, 500, 502, 503, 504, 522, 524]` (suggestions are welcome) 
2. Retry options are 100% configurable.
3. `should_retry/1` is always present if client doesn't pass it to the `retry` opts
4. Client can overwrite `should_retry/1` function