### PR TITLE
Fix crash with empty response on pull call

### DIFF
--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -71,8 +71,10 @@ defmodule BroadwayCloudPubSub.PullClient do
   end
 
   defp handle_response({:ok, response}, :receive_messages) do
-    %{"receivedMessages" => received_messages} = response
-    received_messages
+    case response do
+      %{"receivedMessages" => received_messages} -> received_messages
+      _ -> []
+    end
   end
 
   defp handle_response({:ok, _}, _) do

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -281,6 +281,19 @@ defmodule BroadwayCloudPubSub.PullClientTest do
              } = message3.metadata.attributes
     end
 
+    test "returns an empty list when an empty response is returned by the server", %{
+      opts: base_opts,
+      server: server
+    } do
+      on_pubsub_request(server, fn _, _ ->
+        {:ok, @empty_response}
+      end)
+
+      {:ok, opts} = PullClient.init(base_opts)
+
+      assert [] == PullClient.receive_messages(10, & &1, opts)
+    end
+
     test "if the request fails, returns an empty list and log the error", %{
       opts: base_opts,
       server: server


### PR DESCRIPTION
This PR is to fix #67 

The PubSub JSON api can return an empty response when there are no messages to pull, and right now the code is crashing when that happens.