### PR TITLE
Use :nimble_options package for config validation

### DIFF
--- a/lib/broadway_cloud_pub_sub/acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/acknowledger.ex
@@ -1,7 +1,7 @@
 defmodule BroadwayCloudPubSub.Acknowledger do
   @moduledoc false
   alias Broadway.Acknowledger
-  alias BroadwayCloudPubSub.Client
+  alias BroadwayCloudPubSub.{Client, PipelineOptions}
 
   @behaviour Acknowledger
 
@@ -21,62 +21,12 @@ defmodule BroadwayCloudPubSub.Acknowledger do
 
   @type ack_ref :: reference
 
-  @type t :: %__MODULE__{
-          client: module,
-          client_config: any,
-          on_failure: ack_option,
-          on_success: ack_option
-        }
-
-  @enforce_keys [:client]
-  defstruct [:client, :client_config, on_failure: :noop, on_success: :ack]
-
   # The maximum number of ackIds to be sent in acknowledge/modifyAckDeadline
   # requests. There is an API limit of 524288 bytes (512KiB) per acknowledge/modifyAckDeadline
   # request. ackIds have a maximum size of 184 bytes, so 524288/184 ~= 2849.
   # Accounting for some overhead, a maximum of 2500 ackIds per request should be safe.
   # See https://github.com/googleapis/nodejs-pubsub/pull/65/files#diff-3d29c4447546c72118ed5d5cbf38ab8bR34-R42
   @max_ack_ids_per_request 2_500
-
-  @doc """
-  Initializes this acknowledger for use with a `BroadwayCloudPubSub.Client`.
-
-  ## Options
-
-  The following options are usually provided by `BroadwayCloudPubSub.Producer`:
-
-    * `client` - The client module integrating with the #{inspect(__MODULE__)}.
-
-    * `on_success` - Optional. The action to perform for successful messages. Default is `:ack`.
-
-    * `on_failure` - The action to perform for failed messages. Default is `:noop`.
-  """
-  @spec init(module, term, keyword) :: {:ok, ack_ref} | {:error, message :: binary}
-  def init(client, config, opts) do
-    with {:ok, on_success} <- validate(opts, :on_success, :ack),
-         {:ok, on_failure} <- validate(opts, :on_failure, :noop) do
-      state = %__MODULE__{
-        client: client,
-        client_config: config,
-        on_failure: on_failure,
-        on_success: on_success
-      }
-
-      ack_ref = make_ref()
-      put_config(ack_ref, state)
-
-      {:ok, ack_ref}
-    end
-  end
-
-  defp put_config(reference, state) do
-    :persistent_term.put({__MODULE__, reference}, state)
-  end
-
-  @spec get_config(ack_ref) :: t()
-  def get_config(reference) do
-    :persistent_term.get({__MODULE__, reference})
-  end
 
   @doc """
   Returns an `acknowledger` to be put on a `Broadway.Message`.
@@ -88,7 +38,7 @@ defmodule BroadwayCloudPubSub.Acknowledger do
 
   @impl Acknowledger
   def ack(ack_ref, successful, failed) do
-    config = get_config(ack_ref)
+    config = :persistent_term.get(ack_ref)
 
     success_actions = group_actions_ack_ids(successful, :on_success, config)
     failure_actions = group_actions_ack_ids(failed, :on_failure, config)
@@ -102,17 +52,15 @@ defmodule BroadwayCloudPubSub.Acknowledger do
 
   @impl Acknowledger
   def configure(_ack_ref, ack_data, options) do
-    options = assert_valid_config!(options)
-    ack_data = Map.merge(ack_data, Map.new(options))
-    {:ok, ack_data}
-  end
+    case NimbleOptions.validate(options, PipelineOptions.acknowledger_definition()) do
+      {:ok, opts} ->
+        ack_data = Map.merge(ack_data, Map.new(opts))
+        {:ok, ack_data}
 
-  defp assert_valid_config!(options) do
-    Enum.map(options, fn
-      {:on_success, value} -> {:on_success, validate_option!(:on_success, value)}
-      {:on_failure, value} -> {:on_failure, validate_option!(:on_failure, value)}
-      {other, _value} -> raise ArgumentError, "unsupported configure option #{inspect(other)}"
-    end)
+      {:error, error} ->
+        raise ArgumentError,
+              PipelineOptions.format_error(error, __MODULE__, :configure, 3)
+    end
   end
 
   defp group_actions_ack_ids(messages, key, config) do
@@ -142,42 +90,16 @@ defmodule BroadwayCloudPubSub.Acknowledger do
   defp apply_ack_func(:noop, _ack_ids, _config), do: :ok
 
   defp apply_ack_func(:ack, ack_ids, config) do
-    %__MODULE__{client: client, client_config: opts} = config
-    client.acknowledge(ack_ids, opts)
+    %{client: client} = config
+    client.acknowledge(ack_ids, config)
+  end
+
+  defp apply_ack_func(:nack, ack_ids, config) do
+    apply_ack_func({:nack, 0}, ack_ids, config)
   end
 
   defp apply_ack_func({:nack, deadline}, ack_ids, config) do
-    %__MODULE__{client: client, client_config: opts} = config
-    client.put_deadline(ack_ids, deadline, opts)
+    %{client: client} = config
+    client.put_deadline(ack_ids, deadline, config)
   end
-
-  defp validate(opts, key, default) when is_list(opts) do
-    validate_option(key, opts[key] || default)
-  end
-
-  defp validate_option(action, value) when action in [:on_success, :on_failure] do
-    case validate_action(value) do
-      {:ok, result} -> {:ok, result}
-      :error -> validation_error(action, "a valid acknowledgement option", value)
-    end
-  end
-
-  defp validate_option(_, value), do: {:ok, value}
-
-  defp validate_option!(key, value) do
-    case validate_option(key, value) do
-      {:ok, value} -> value
-      {:error, message} -> raise ArgumentError, message
-    end
-  end
-
-  defp validation_error(option, expected, value) do
-    {:error, "expected #{inspect(option)} to be #{expected}, got: #{inspect(value)}"}
-  end
-
-  defp validate_action(:ack), do: {:ok, :ack}
-  defp validate_action(:noop), do: {:ok, :noop}
-  defp validate_action(:nack), do: {:ok, {:nack, 0}}
-  defp validate_action({:nack, n}) when is_integer(n) and n >= 0, do: {:ok, {:nack, n}}
-  defp validate_action(_), do: :error
 end

--- a/lib/broadway_cloud_pub_sub/acknowledger.ex
+++ b/lib/broadway_cloud_pub_sub/acknowledger.ex
@@ -1,7 +1,7 @@
 defmodule BroadwayCloudPubSub.Acknowledger do
   @moduledoc false
   alias Broadway.Acknowledger
-  alias BroadwayCloudPubSub.{Client, PipelineOptions}
+  alias BroadwayCloudPubSub.{Client, Options}
 
   @behaviour Acknowledger
 
@@ -52,14 +52,14 @@ defmodule BroadwayCloudPubSub.Acknowledger do
 
   @impl Acknowledger
   def configure(_ack_ref, ack_data, options) do
-    case NimbleOptions.validate(options, PipelineOptions.acknowledger_definition()) do
+    case NimbleOptions.validate(options, Options.acknowledger_definition()) do
       {:ok, opts} ->
         ack_data = Map.merge(ack_data, Map.new(opts))
         {:ok, ack_data}
 
       {:error, error} ->
         raise ArgumentError,
-              PipelineOptions.format_error(error, __MODULE__, :configure, 3)
+              Options.format_error(error, __MODULE__, :configure, 3)
     end
   end
 

--- a/lib/broadway_cloud_pub_sub/options.ex
+++ b/lib/broadway_cloud_pub_sub/options.ex
@@ -1,4 +1,4 @@
-defmodule BroadwayCloudPubSub.PipelineOptions do
+defmodule BroadwayCloudPubSub.Options do
   @moduledoc false
   alias NimbleOptions.ValidationError
   require Logger

--- a/lib/broadway_cloud_pub_sub/pipeline_options.ex
+++ b/lib/broadway_cloud_pub_sub/pipeline_options.ex
@@ -2,176 +2,138 @@ defmodule BroadwayCloudPubSub.PipelineOptions do
   @moduledoc false
   require Logger
 
+  @default_base_url "https://pubsub.googleapis.com"
+
   @default_max_number_of_messages 10
+
+  @default_receive_interval 5_000
 
   @default_scope "https://www.googleapis.com/auth/pubsub"
 
-  @valid_ack_values [:ack, :nack, :noop]
-
-  # TODO: validate {:nack, integer()} as an ack value
-  def definition do
-    [
-      client: [
-        type: :atom,
-        default: BroadwayCloudPubSub.PullClient,
-        doc: """
-        A module that implements the BroadwayCloudPubSub.Client behaviour.
-        This module is responsible for fetching and acknowledging the messages.
-        Pay attention that all options passed to the producer will be forwarded
-        to the client. It's up to the client to normalize the options it needs.
-        """
-      ],
-      subscription: [
-        type: :string,
-        required: true,
-        doc: """
-        The name of the subscription, including the project.
-        For example, if you project is named `"my-project"` and your
-        subscription is named `"my-subscription"`, then your subscription
-        name is `"projects/my-project/subscriptions/my-subscription"`.
-        """
-      ],
-      max_number_of_messages: [
-        doc: "The maximum number of messages to be fetched per request.",
-        type: :integer,
-        default: 10
-      ],
-      on_failure: [
-        type: {:in, @valid_ack_values},
-        doc: """
-        Configures the acking behaviour for failed messages.
-        See the "Acknowledgements" section below for all the possible values.
-        This option can also be changed for each message through
-        `Broadway.Message.configure_ack/2`.
-        """,
-        default: :noop
-      ],
-      on_success: [
-        type: {:in, @valid_ack_values},
-        doc: """
-        Configures the acking behaviour for successful messages.
-        See the "Acknowledgements" section below for all the possible values.
-        This option can also be changed for each message through
-        `Broadway.Message.configure_ack/2`.
-        """,
-        default: :ack
-      ],
-      pool_size: [
-        type: {:custom, __MODULE__, :validate_pool_size, []},
-        doc: """
-        The size of the connection pool.
-        The default value is twice the producer concurrency.
-        """
-      ],
-      receive_interval: [
-        type: :integer,
-        default: 5_000,
-        doc: """
-        The duration (in milliseconds) for which the producer waits
-        before making a request for more messages.
-        """
-      ],
-      scope: [
-        type: :string,
-        default: "https://www.googleapis.com/auth/pubsub",
-        doc: """
-        A string representing the scope or scopes to use when fetching
-        an access token. Note that the `:scope` option only applies to the
-        default token generator.
-        """
-      ],
-      token_generator: [
-        type: :mfa,
-        default: {__MODULE__, :generate_goth_token, []},
-        doc: """
-        An MFArgs tuple that will be called before each request
-        to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
-        By default this will invoke `Goth.Token.for_scope/1` with `"https://www.googleapis.com/auth/pubsub"`.
-        See the "Custom token generator" section below for more information.
-        """
-      ],
-      base_url: [
-        doc: "The base URL for the Cloud PubSub services.",
-        type: :string,
-        default: "https://pubsub.googleapis.com"
-      ]
+  definition = [
+    # Internal.
+    finch_name: [type: :atom, doc: false],
+    # Handled by Broadway.
+    broadway: [type: :any, doc: false],
+    client: [
+      type: :atom,
+      default: BroadwayCloudPubSub.PullClient,
+      doc: """
+      A module that implements the BroadwayCloudPubSub.Client behaviour.
+      This module is responsible for fetching and acknowledging the messages.
+      Pay attention that all options passed to the producer will be forwarded
+      to the client. It's up to the client to normalize the options it needs.
+      """
+    ],
+    subscription: [
+      type: {:custom, __MODULE__, :type_non_empty_string, [[{:name, :subscription}]]},
+      required: true,
+      doc: """
+      The name of the subscription, including the project.
+      For example, if you project is named `"my-project"` and your
+      subscription is named `"my-subscription"`, then your subscription
+      name is `"projects/my-project/subscriptions/my-subscription"`.
+      """
+    ],
+    max_number_of_messages: [
+      doc: "The maximum number of messages to be fetched per request.",
+      type: :pos_integer,
+      default: @default_max_number_of_messages
+    ],
+    on_failure: [
+      type:
+        {:custom, __MODULE__, :type_atom_action_or_nack_with_bounded_integer,
+         [[{:name, :on_failure}, {:min, 0}, {:max, 600}]]},
+      doc: """
+      Configures the acking behaviour for failed messages.
+      See the "Acknowledgements" section below for all the possible values.
+      This option can also be changed for each message through
+      `Broadway.Message.configure_ack/2`.
+      """,
+      default: :noop
+    ],
+    on_success: [
+      type:
+        {:custom, __MODULE__, :type_atom_action_or_nack_with_bounded_integer,
+         [[{:name, :on_success}, {:min, 0}, {:max, 600}]]},
+      doc: """
+      Configures the acking behaviour for successful messages.
+      See the "Acknowledgements" section below for all the possible values.
+      This option can also be changed for each message through
+      `Broadway.Message.configure_ack/2`.
+      """,
+      default: :ack
+    ],
+    receive_interval: [
+      type: :integer,
+      default: @default_receive_interval,
+      doc: """
+      The duration (in milliseconds) for which the producer waits
+      before making a request for more messages.
+      """
+    ],
+    scope: [
+      type: {:custom, __MODULE__, :type_non_empty_string_or_tagged_tuple, [[{:name, :scope}]]},
+      default: @default_scope,
+      doc: """
+      A string representing the scope or scopes to use when fetching
+      an access token. Note that this option only applies to the
+      default token generator.
+      """
+    ],
+    token_generator: [
+      type: :mfa,
+      doc: """
+      An MFArgs tuple that will be called before each request
+      to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
+      By default this will invoke `Goth.Token.for_scope/1` with `"#{@default_scope}"`.
+      See the "Custom token generator" section below for more information.
+      """
+    ],
+    base_url: [
+      type: {:custom, __MODULE__, :type_non_empty_string, [[{:name, :base_url}]]},
+      default: @default_base_url,
+      doc: """
+      The base URL for the Cloud Pub/Sub service.
+      This option is mostly useful for testing via the Pub/Sub emulator.
+      """
+    ],
+    pool_size: [
+      type: :pos_integer,
+      doc: """
+      The size of the connection pool.
+      The default value is twice the producer concurrency.
+      """
+    ],
+    return_immediately: [
+      doc: false,
+      deprecated: "Google Pub/Sub will remove this option in the future.",
+      type: :boolean
+    ],
+    # Testing Options
+    test_pid: [
+      type: :pid,
+      doc: false
+    ],
+    message_server: [
+      type: :pid,
+      doc: false
     ]
+  ]
+
+  @opts_schema NimbleOptions.new!(definition)
+
+  def definition do
+    @opts_schema
   end
 
-  def validate_pool_size(opts) do
-    IO.inspect(opts, label: :pool_size)
-    2
-  end
-
-  def validate(opts) do
-    with {:ok, opts} <- NimbleOptions.validate(opts, definition()) do
-      config = %{
-        subscription: Keyword.fetch!(opts, :subscription),
-        token_generator: Keyword.fetch!(opts, :token_generator),
-        pull_request: Keyword.fetch!(opts, :pull_request)
-      }
-
-      {:ok, config}
-    end
-  end
-
-  defp validate(opts, key, default \\ nil) when is_list(opts) do
-    validate_option(key, opts[key] || default)
-  end
-
-  defp validate_option(:token_generator, {m, f, args})
-       when is_atom(m) and is_atom(f) and is_list(args) do
-    {:ok, {m, f, args}}
-  end
-
-  defp validate_option(:token_generator, value),
-    do: validation_error(:token_generator, "a tuple {Mod, Fun, Args}", value)
-
-  defp validate_option(:scope, value)
-       when not (is_binary(value) or is_tuple(value)) or (value == "" or value == {}),
-       do: validation_error(:scope, "a non empty string or tuple", value)
-
-  defp validate_option(:subscription, value) when not is_binary(value) or value == "",
-    do: validation_error(:subscription, "a non empty string", value)
-
-  defp validate_option(:max_number_of_messages, value) when not is_integer(value) or value < 1,
-    do: validation_error(:max_number_of_messages, "a positive integer", value)
-
-  defp validate_option(:return_immediately, nil), do: {:ok, nil}
-
-  defp validate_option(:return_immediately, value) when not is_boolean(value),
-    do: validation_error(:return_immediately, "a boolean value", value)
-
-  defp validate_option(_, value), do: {:ok, value}
-
-  defp validation_error(option, expected, value) do
-    {:error, "expected #{inspect(option)} to be #{expected}, got: #{inspect(value)}"}
-  end
-
-  defp validate_pull_request(opts) do
-    with {:ok, return_immediately} <- validate(opts, :return_immediately),
-         {:ok, max_number_of_messages} <-
-           validate(opts, :max_number_of_messages, @default_max_number_of_messages) do
-      {:ok,
-       %{
-         maxMessages: max_number_of_messages,
-         returnImmediately: return_immediately
-       }}
-    end
-  end
-
-  defp validate_token_opts(opts) do
-    case Keyword.fetch(opts, :token_generator) do
-      {:ok, _} -> validate(opts, :token_generator)
-      :error -> validate_scope(opts)
-    end
-  end
-
-  defp validate_scope(opts) do
-    with {:ok, scope} <- validate(opts, :scope, @default_scope) do
-      ensure_goth_loaded()
-      {:ok, {__MODULE__, :generate_goth_token, [scope]}}
-    end
+  @doc """
+  Builds an MFArgs tuple for a token generator.
+  """
+  def make_token_generator(opts) do
+    scope = Keyword.fetch!(opts, :scope)
+    ensure_goth_loaded()
+    {__MODULE__, :generate_goth_token, [scope]}
   end
 
   defp ensure_goth_loaded() do
@@ -200,23 +162,56 @@ defmodule BroadwayCloudPubSub.PipelineOptions do
     end
   end
 
-  defp validate_subscription(opts) do
-    with {:ok, subscription} <- validate(opts, :subscription) do
-      subscription |> String.split("/") |> validate_sub_parts(subscription)
-    end
+  def type_atom_action_or_nack_with_bounded_integer(:ack, [{:name, _}, {:min, _}, {:max, _}]) do
+    {:ok, :ack}
   end
 
-  defp validate_sub_parts(
-         ["projects", projects_id, "subscriptions", subscriptions_id] = parts,
-         _subscription
-       ) do
-    string = Enum.join(parts, "/")
-
-    {:ok, %{projects_id: projects_id, subscriptions_id: subscriptions_id, string: string}}
+  def type_atom_action_or_nack_with_bounded_integer(:noop, [{:name, _}, {:min, _}, {:max, _}]) do
+    {:ok, :noop}
   end
 
-  defp validate_sub_parts(_, subscription) do
-    validation_error(:subscription, "an valid subscription name", subscription)
+  def type_atom_action_or_nack_with_bounded_integer(:nack, [{:name, _}, {:min, _}, {:max, _}]) do
+    {:ok, {:nack, 0}}
+  end
+
+  def type_atom_action_or_nack_with_bounded_integer(
+        {:nack, value},
+        [{:name, _}, {:min, min}, {:max, max}]
+      )
+      when is_integer(value) and value >= min and value <= max do
+    {:ok, {:nack, value}}
+  end
+
+  def type_atom_action_or_nack_with_bounded_integer(value, [
+        {:name, name},
+        {:min, min},
+        {:max, max}
+      ]) do
+    {:error,
+     "expected :#{name} to be one of :ack, :noop, :nack, or {:nack, integer} where " <>
+       "integer is between #{min} and #{max}, got: #{inspect(value)}"}
+  end
+
+  def type_non_empty_string("", [{:name, name}]) do
+    {:error, "expected :#{name} to be a non-empty string, got: \"\""}
+  end
+
+  def type_non_empty_string(value, _)
+      when not is_nil(value) and is_binary(value) do
+    {:ok, value}
+  end
+
+  def type_non_empty_string(value, [{:name, name}]) do
+    {:error, "expected :#{name} to be a non-empty string, got: #{inspect(value)}"}
+  end
+
+  def type_non_empty_string_or_tagged_tuple(value, [{:name, name}])
+      when not (is_binary(value) or is_tuple(value)) or (value == "" or value == {}) do
+    {:error, "expected :#{name} to be a non-empty string or tuple, got: #{inspect(value)}"}
+  end
+
+  def type_non_empty_string_or_tagged_tuple(value, _) do
+    {:ok, value}
   end
 
   @doc false

--- a/lib/broadway_cloud_pub_sub/pipeline_options.ex
+++ b/lib/broadway_cloud_pub_sub/pipeline_options.ex
@@ -1,5 +1,6 @@
 defmodule BroadwayCloudPubSub.PipelineOptions do
   @moduledoc false
+  alias NimbleOptions.ValidationError
   require Logger
 
   @default_base_url "https://pubsub.googleapis.com"
@@ -121,10 +122,18 @@ defmodule BroadwayCloudPubSub.PipelineOptions do
     ]
   ]
 
-  @opts_schema NimbleOptions.new!(definition)
+  @definition NimbleOptions.new!(definition)
 
   def definition do
-    @opts_schema
+    @definition
+  end
+
+  @acknowledger_definition definition
+                           |> Keyword.take([:on_failure, :on_success])
+                           |> NimbleOptions.new!()
+
+  def acknowledger_definition do
+    @acknowledger_definition
   end
 
   @doc """
@@ -212,6 +221,15 @@ defmodule BroadwayCloudPubSub.PipelineOptions do
 
   def type_non_empty_string_or_tagged_tuple(value, _) do
     {:ok, value}
+  end
+
+  def format_error(%ValidationError{keys_path: [], message: message}, mod, fun, arity) do
+    "invalid configuration given to #{inspect(mod)}.#{fun}/#{arity}, " <> message
+  end
+
+  def format_error(%ValidationError{keys_path: keys_path, message: message}, mod, fun, arity) do
+    "invalid configuration given to #{inspect(mod)}.#{fun}/#{arity} for key #{inspect(keys_path)}, " <>
+      message
   end
 
   @doc false

--- a/lib/broadway_cloud_pub_sub/pipeline_options.ex
+++ b/lib/broadway_cloud_pub_sub/pipeline_options.ex
@@ -6,16 +6,109 @@ defmodule BroadwayCloudPubSub.PipelineOptions do
 
   @default_scope "https://www.googleapis.com/auth/pubsub"
 
+  @valid_ack_values [:ack, :nack, :noop]
+
+  # TODO: validate {:nack, integer()} as an ack value
+  def definition do
+    [
+      client: [
+        type: :atom,
+        default: BroadwayCloudPubSub.PullClient,
+        doc: """
+        A module that implements the BroadwayCloudPubSub.Client behaviour.
+        This module is responsible for fetching and acknowledging the messages.
+        Pay attention that all options passed to the producer will be forwarded
+        to the client. It's up to the client to normalize the options it needs.
+        """
+      ],
+      subscription: [
+        type: :string,
+        required: true,
+        doc: """
+        The name of the subscription, including the project.
+        For example, if you project is named `"my-project"` and your
+        subscription is named `"my-subscription"`, then your subscription
+        name is `"projects/my-project/subscriptions/my-subscription"`.
+        """
+      ],
+      max_number_of_messages: [
+        doc: "The maximum number of messages to be fetched per request.",
+        type: :integer,
+        default: 10
+      ],
+      on_failure: [
+        type: {:in, @valid_ack_values},
+        doc: """
+        Configures the acking behaviour for failed messages.
+        See the "Acknowledgements" section below for all the possible values.
+        This option can also be changed for each message through
+        `Broadway.Message.configure_ack/2`.
+        """,
+        default: :noop
+      ],
+      on_success: [
+        type: {:in, @valid_ack_values},
+        doc: """
+        Configures the acking behaviour for successful messages.
+        See the "Acknowledgements" section below for all the possible values.
+        This option can also be changed for each message through
+        `Broadway.Message.configure_ack/2`.
+        """,
+        default: :ack
+      ],
+      pool_size: [
+        type: {:custom, __MODULE__, :validate_pool_size, []},
+        doc: """
+        The size of the connection pool.
+        The default value is twice the producer concurrency.
+        """
+      ],
+      receive_interval: [
+        type: :integer,
+        default: 5_000,
+        doc: """
+        The duration (in milliseconds) for which the producer waits
+        before making a request for more messages.
+        """
+      ],
+      scope: [
+        type: :string,
+        default: "https://www.googleapis.com/auth/pubsub",
+        doc: """
+        A string representing the scope or scopes to use when fetching
+        an access token. Note that the `:scope` option only applies to the
+        default token generator.
+        """
+      ],
+      token_generator: [
+        type: :mfa,
+        default: {__MODULE__, :generate_goth_token, []},
+        doc: """
+        An MFArgs tuple that will be called before each request
+        to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
+        By default this will invoke `Goth.Token.for_scope/1` with `"https://www.googleapis.com/auth/pubsub"`.
+        See the "Custom token generator" section below for more information.
+        """
+      ],
+      base_url: [
+        doc: "The base URL for the Cloud PubSub services.",
+        type: :string,
+        default: "https://pubsub.googleapis.com"
+      ]
+    ]
+  end
+
+  def validate_pool_size(opts) do
+    IO.inspect(opts, label: :pool_size)
+    2
+  end
+
   def validate(opts) do
-    with(
-      {:ok, subscription} <- validate_subscription(opts),
-      {:ok, token_generator} <- validate_token_opts(opts),
-      {:ok, pull_request} <- validate_pull_request(opts)
-    ) do
+    with {:ok, opts} <- NimbleOptions.validate(opts, definition()) do
       config = %{
-        subscription: subscription,
-        token_generator: token_generator,
-        pull_request: pull_request
+        subscription: Keyword.fetch!(opts, :subscription),
+        token_generator: Keyword.fetch!(opts, :token_generator),
+        pull_request: Keyword.fetch!(opts, :pull_request)
       }
 
       {:ok, config}

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -16,7 +16,7 @@ defmodule BroadwayCloudPubSub.Producer do
   producers (regardless of the client implementation), all other options are specific to
   the `BroadwayCloudPubSub.PullClient`, which is the default client.
 
-  #{NimbleOptions.docs(BroadwayCloudPubSub.PipelineOptions.definition())}
+  #{NimbleOptions.docs(BroadwayCloudPubSub.Options.definition())}
 
   ### Custom token generator
 
@@ -104,8 +104,7 @@ defmodule BroadwayCloudPubSub.Producer do
 
   use GenStage
   alias Broadway.Producer
-  alias BroadwayCloudPubSub.Acknowledger
-  alias BroadwayCloudPubSub.PipelineOptions
+  alias BroadwayCloudPubSub.{Acknowledger, Options}
 
   @behaviour Producer
 
@@ -136,10 +135,10 @@ defmodule BroadwayCloudPubSub.Producer do
         2 * broadway_opts[:producer][:concurrency]
       end)
 
-    case NimbleOptions.validate(client_opts, PipelineOptions.definition()) do
+    case NimbleOptions.validate(client_opts, Options.definition()) do
       {:error, error} ->
         raise ArgumentError,
-              PipelineOptions.format_error(error, __MODULE__, :prepare_for_start, 2)
+              Options.format_error(error, __MODULE__, :prepare_for_start, 2)
 
       {:ok, opts} ->
         ack_ref = broadway_opts[:name]
@@ -147,7 +146,7 @@ defmodule BroadwayCloudPubSub.Producer do
 
         opts =
           Keyword.put_new_lazy(opts, :token_generator, fn ->
-            PipelineOptions.make_token_generator(opts)
+            Options.make_token_generator(opts)
           end)
 
         {specs, opts} = prepare_to_connect(module, client, opts)

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -106,7 +106,6 @@ defmodule BroadwayCloudPubSub.Producer do
   alias Broadway.Producer
   alias BroadwayCloudPubSub.Acknowledger
   alias BroadwayCloudPubSub.PipelineOptions
-  alias NimbleOptions.ValidationError
 
   @behaviour Producer
 
@@ -139,7 +138,8 @@ defmodule BroadwayCloudPubSub.Producer do
 
     case NimbleOptions.validate(client_opts, PipelineOptions.definition()) do
       {:error, error} ->
-        raise ArgumentError, format_error(error)
+        raise ArgumentError,
+              PipelineOptions.format_error(error, __MODULE__, :prepare_for_start, 2)
 
       {:ok, opts} ->
         ack_ref = broadway_opts[:name]
@@ -167,15 +167,6 @@ defmodule BroadwayCloudPubSub.Producer do
     else
       {[], producer_opts}
     end
-  end
-
-  defp format_error(%ValidationError{keys_path: [], message: message}) do
-    "invalid configuration given to BroadwayCloudPubSub.Producer.prepare_for_start/2, " <> message
-  end
-
-  defp format_error(%ValidationError{keys_path: keys_path, message: message}) do
-    "invalid configuration given to BroadwayCloudPubSub.Producer.prepare_for_start/2 for key #{inspect(keys_path)}, " <>
-      message
   end
 
   @impl true

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -7,25 +7,16 @@ defmodule BroadwayCloudPubSub.Producer do
   Pub/Sub, but you can provide your client by implementing the `BroadwayCloudPubSub.Client`
   behaviour.
 
-  ## Options using `BroadwayCloudPubSub.PullClient`
+  For a quick getting started on using Broadway with Cloud Pub/Sub, please see
+  the [Google Cloud Pub/Sub Guide](https://hexdocs.pm/broadway/google-cloud-pubsub.html).
 
-    * `:subscription` - Required. The name of the subscription.
-      Example: "projects/my-project/subscriptions/my-subscription"
+  ## Options
 
-    * `:max_number_of_messages` - Optional. The maximum number of messages to be fetched
-      per request. Default is `10`.
+  Aside from `:receive_interval` and `:client` which are generic and apply to all
+  producers (regardless of the client implementation), all other options are specific to
+  the `BroadwayCloudPubSub.PullClient`, which is the default client.
 
-    * `:scope` - Optional. A string representing the scope or scopes to use when fetching
-       an access token. Default is `"https://www.googleapis.com/auth/pubsub"`.
-       Note: The `:scope` option only applies to the default token generator.
-
-    * `:token_generator` - Optional. An MFArgs tuple that will be called before each request
-      to fetch an authentication token. It should return `{:ok, String.t()} | {:error, any()}`.
-      Default generator uses `Goth.Token.for_scope/1` with `"https://www.googleapis.com/auth/pubsub"`.
-      See "Custom token generator" section below for more information.
-
-    * `:base_url` - Optional. The base URL for the Cloud PubSub services.
-      Default is "https://pubsub.googleapis.com".
+  #{NimbleOptions.docs(BroadwayCloudPubSub.PipelineOptions.definition())}
 
   ### Custom token generator
 
@@ -46,36 +37,6 @@ defmodule BroadwayCloudPubSub.Producer do
   and configure the producer to use it:
 
       token_generator: {MyApp, :fetch_token, []}
-
-  ## Acknowledger options
-
-  These options apply to `BroadwayCloudPubSub.PullClient` acknowledgement API:
-
-    * `:on_success` - Optional. Configures the behaviour for successful messages.
-       See the "Acknowledgements" section below for all the possible values.
-       This option can also be changed for each message through `Broadway.Message.configure_ack/2`.
-       Default is `:ack`.
-
-    * `:on_failure` - Optional. Configures the behaviour for failed messages.
-       See the "Acknowledgements" section below for all the possible values. This
-       option can also be changed for each message through `Broadway.Message.configure_ack/2`.
-       Default is `:noop`.
-
-  ## Additional options
-
-  These options apply to all producers, regardless of client implementation:
-
-    * `:client` - Optional. A module that implements the `BroadwayCloudPubSub.Client`
-      behaviour. This module is responsible for fetching and acknowledging the
-      messages. Pay attention that all options passed to the producer will be forwarded
-      to the client. It's up to the client to normalize the options it needs. Default
-      is `BroadwayCloudPubSub.PullClient`.
-
-    * `:pool_size` - Optional. The size of the connection pool. Default is
-       twice the producer concurrency.
-
-    * `:receive_interval` - Optional. The duration (in milliseconds) for which the producer
-      waits before making a request for more messages. Default is 5000.
 
   ## Acknowledgements
 
@@ -147,23 +108,43 @@ defmodule BroadwayCloudPubSub.Producer do
 
   @behaviour Producer
 
-  @default_base_url "https://pubsub.googleapis.com"
-  @default_client BroadwayCloudPubSub.PullClient
-  @default_receive_interval 5000
+  @impl GenStage
+  def init(opts) do
+    receive_interval = opts[:receive_interval]
+    client = opts[:client]
+
+    {:ok, config} = client.init(opts)
+    {:ok, ack_ref} = Acknowledger.init(client, config, opts)
+
+    {:producer,
+     %{
+       demand: 0,
+       receive_timer: nil,
+       receive_interval: receive_interval,
+       client: {client, config},
+       ack_ref: ack_ref
+     }}
+  end
 
   @impl Producer
-  def prepare_for_start(module, opts) do
-    {me, my_opts} = opts[:producer][:module]
-    client = Keyword.get(my_opts, :client, @default_client)
+  def prepare_for_start(module, broadway_opts) do
+    {producer_module, client_opts} = broadway_opts[:producer][:module]
 
-    my_opts =
-      Keyword.put_new_lazy(my_opts, :pool_size, fn ->
-        2 * opts[:producer][:concurrency]
-      end)
+    # TODO: set empty pool_size to 2 * broadway_opts[:producer][:concurrency]
+    case NimbleOptions.validate(client_opts, BroadwayCloudPubSub.PipelineOptions.definition()) do
+      {:error, error} ->
+        raise ArgumentError, format_error(error)
 
-    {specs, my_opts} = prepare_to_connect(module, client, my_opts)
+      {:ok, opts} ->
+        client = opts[:client]
 
-    {specs, put_in(opts, [:producer, :module], {me, my_opts})}
+        {specs, opts} = prepare_to_connect(module, client, opts)
+
+        broadway_opts_with_defaults =
+          put_in(broadway_opts, [:producer, :module], {producer_module, opts})
+
+        {specs, broadway_opts_with_defaults}
+    end
   end
 
   defp prepare_to_connect(module, client, producer_opts) do
@@ -174,25 +155,9 @@ defmodule BroadwayCloudPubSub.Producer do
     end
   end
 
-  @impl true
-  def init(opts) do
-    client = opts[:client] || @default_client
-    receive_interval = opts[:receive_interval] || @default_receive_interval
-    opts = Keyword.put_new(opts, :base_url, @default_base_url)
-
-    with {:ok, config} <- client.init(opts),
-         {:ok, ack_ref} <- Acknowledger.init(client, config, opts) do
-      {:producer,
-       %{
-         demand: 0,
-         receive_timer: nil,
-         receive_interval: receive_interval,
-         client: {client, config},
-         ack_ref: ack_ref
-       }}
-    else
-      {:error, message} -> raise ArgumentError, message
-    end
+  # TODO: really format errors :-)
+  defp format_error(error) do
+    "#{inspect(error)}"
   end
 
   @impl true

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -1,10 +1,9 @@
 defmodule BroadwayCloudPubSub.PullClient do
   @moduledoc """
-  Pull client using Finch.
+  A subscriptions [pull client](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull) built on `Finch`.
   """
   alias Broadway.Message
   alias BroadwayCloudPubSub.Client
-  alias BroadwayCloudPubSub.PipelineOptions
   alias Finch.Response
 
   require Logger
@@ -18,27 +17,20 @@ defmodule BroadwayCloudPubSub.PullClient do
 
     finch_name = Module.concat(name, PullClient)
 
-    children = [
+    specs = [
       {Finch, name: finch_name, pools: %{default: [size: pool_size]}}
     ]
 
     producer_opts = Keyword.put(producer_opts, :finch_name, finch_name)
 
-    {children, producer_opts}
+    {specs, producer_opts}
   end
 
   @impl Client
   def init(opts) do
-    with {:ok, pipeline_config} <- PipelineOptions.validate(opts) do
-      api_config = %{
-        finch_name: opts[:finch_name],
-        base_url: opts[:base_url]
-      }
+    opts_map = Map.new(opts)
 
-      finch_config = Map.merge(pipeline_config, api_config)
-
-      {:ok, finch_config}
-    end
+    {:ok, opts_map}
   end
 
   @impl Client

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -28,14 +28,12 @@ defmodule BroadwayCloudPubSub.PullClient do
 
   @impl Client
   def init(opts) do
-    opts_map = Map.new(opts)
-
-    {:ok, opts_map}
+    {:ok, Map.new(opts)}
   end
 
   @impl Client
   def receive_messages(demand, ack_builder, config) do
-    max_messages = min(demand, config.pull_request.maxMessages)
+    max_messages = min(demand, config.max_number_of_messages)
 
     config
     |> execute(:pull, %{"maxMessages" => max_messages})
@@ -145,7 +143,7 @@ defmodule BroadwayCloudPubSub.PullClient do
   defp url(config, :modack), do: url(config, @mod_ack_action)
 
   defp url(config, action) do
-    sub = URI.encode(config.subscription.string)
+    sub = URI.encode(config.subscription)
     path = "/v1/" <> sub <> ":" <> to_string(action)
     config.base_url <> path
   end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,8 @@ defmodule BroadwayCloudPubSub.MixProject do
       {:broadway, "~> 1.0"},
       {:finch, "~> 0.9.0"},
       {:jason, "~> 1.0"},
-      {:nimble_options, "~> 0.3.5"},
+      {:nimble_options, "~> 0.3.7"},
+      {:telemetry, "~> 0.4.3 or ~> 1.0"},
       {:goth, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.23", only: :docs},
       {:bypass, "~> 2.1", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule BroadwayCloudPubSub.MixProject do
       {:broadway, "~> 1.0"},
       {:finch, "~> 0.9.0"},
       {:jason, "~> 1.0"},
+      {:nimble_options, "~> 0.3.5"},
       {:goth, "~> 1.0", optional: true},
       {:ex_doc, "~> 0.23", only: :docs},
       {:bypass, "~> 2.1", only: :test}

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -327,7 +327,7 @@ defmodule BroadwayCloudPubSub.ProducerTest do
               ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
 
       assert producer_opts[:token_generator] ==
-               {BroadwayCloudPubSub.PipelineOptions, :generate_goth_token,
+               {BroadwayCloudPubSub.Options, :generate_goth_token,
                 ["https://www.googleapis.com/auth/pubsub"]}
     end
 

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -110,19 +110,449 @@ defmodule BroadwayCloudPubSub.ProducerTest do
     end
   end
 
-  test "raise an ArgumentError with proper message when client options are invalid" do
-    assert_raise(
-      ArgumentError,
-      "expected :subscription to be a non empty string, got: nil",
-      fn ->
-        BroadwayCloudPubSub.Producer.init(subscription: nil)
+  defp prepare_for_start_module_opts(module_opts) do
+    {:ok, message_server} = MessageServer.start_link()
+    {:ok, pid} = start_broadway(message_server)
+
+    try do
+      BroadwayCloudPubSub.Producer.prepare_for_start(Forwarder,
+        producer: [
+          module: {BroadwayCloudPubSub.Producer, module_opts},
+          concurrency: 1
+        ]
+      )
+    after
+      stop_broadway(pid)
+    end
+  end
+
+  describe "prepare_for_start/2 validation" do
+    test ":subcription should be a string" do
+      message = """
+      invalid configuration given to BroadwayCloudPubSub.Producer.prepare_for_start/2, \
+      required option :subscription not found, received options: [:client, :pool_size]\
+      """
+
+      assert_raise(ArgumentError, message, fn ->
+        prepare_for_start_module_opts([])
+      end)
+
+      assert_raise(
+        ArgumentError,
+        ~r/expected :subscription to be a non-empty string, got: nil/,
+        fn ->
+          prepare_for_start_module_opts(subscription: nil)
+        end
+      )
+
+      assert_raise(
+        ArgumentError,
+        ~r/expected :subscription to be a non-empty string, got: \"\"/,
+        fn ->
+          prepare_for_start_module_opts(subscription: "")
+        end
+      )
+
+      assert_raise(
+        ArgumentError,
+        ~r/expected :subscription to be a non-empty string, got: :foo/,
+        fn ->
+          prepare_for_start_module_opts(subscription: :foo)
+        end
+      )
+
+      assert {
+               _,
+               [
+                 producer: [
+                   module: {BroadwayCloudPubSub.Producer, producer_opts},
+                   concurrency: 1
+                 ]
+               ]
+             } = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:subscription] == "projects/foo/subscriptions/bar"
+    end
+
+    test ":max_number_of_messages is optional with default value 10" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:max_number_of_messages] == 10
+    end
+
+    test ":max_number_of_messages should be a positive integer" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, result_module_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 max_number_of_messages: 1
+               )
+
+      assert result_module_opts[:max_number_of_messages] == 1
+
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, result_module_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 max_number_of_messages: 10
+               )
+
+      assert result_module_opts[:max_number_of_messages] == 10
+
+      assert_raise(
+        ArgumentError,
+        ~r/expected :max_number_of_messages to be a positive integer, got: 0/,
+        fn ->
+          prepare_for_start_module_opts(
+            subscription: "projects/foo/subscriptions/bar",
+            max_number_of_messages: 0
+          )
+        end
+      )
+
+      assert_raise(
+        ArgumentError,
+        ~r/expected :max_number_of_messages to be a positive integer, got: -1/,
+        fn ->
+          prepare_for_start_module_opts(
+            subscription: "projects/foo/subscriptions/bar",
+            max_number_of_messages: -1
+          )
+        end
+      )
+    end
+
+    test ":scope is optional with a default value https://www.googleapis.com/auth/pubsub" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:scope] == "https://www.googleapis.com/auth/pubsub"
+    end
+
+    test ":scope should be a string or tuple" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 scope: "https://example.com"
+               )
+
+      assert {_, _, ["https://example.com"]} = producer_opts[:token_generator]
+
+      assert_raise ArgumentError,
+                   ~r/expected :scope to be a non-empty string or tuple, got: :an_atom/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       scope: :an_atom
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :scope to be a non-empty string or tuple, got: 1/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       scope: 1
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :scope to be a non-empty string or tuple, got: {}/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       scope: {}
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :scope to be a non-empty string or tuple, got: {}/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       scope: {}
+                     )
+                   end
+
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 scope: {"mail@example.com", "https://example.com"}
+               )
+
+      assert {_, _, [{"mail@example.com", "https://example.com"}]} =
+               producer_opts[:token_generator]
+    end
+
+    test ":token_generator defaults to using Goth with default scope" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:token_generator] ==
+               {BroadwayCloudPubSub.PipelineOptions, :generate_goth_token,
+                ["https://www.googleapis.com/auth/pubsub"]}
+    end
+
+    test ":token_generator should be a tuple {Mod, Fun, Args}" do
+      token_generator = {Token, :fetch, []}
+
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 token_generator: token_generator
+               )
+
+      assert producer_opts[:token_generator] == token_generator
+
+      assert_raise ArgumentError,
+                   ~r/expected :token_generator to be a tuple {Mod, Fun, Args}, got: {1, 1, 1}/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       token_generator: {1, 1, 1}
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :token_generator to be a tuple {Mod, Fun, Args}, got: SomeModule/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       token_generator: SomeModule
+                     )
+                   end
+    end
+
+    test ":on_success defaults to :ack" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:on_success] == :ack
+    end
+
+    test ":on_failure defaults to :noop" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:on_failure] == :noop
+    end
+
+    test ":on_success should be a valid action" do
+      for action <- [:ack, :noop, {:nack, 0}, {:nack, 100}, {:nack, 600}] do
+        assert {_,
+                [
+                  producer: [
+                    module: {BroadwayCloudPubSub.Producer, producer_opts},
+                    concurrency: 1
+                  ]
+                ]} =
+                 prepare_for_start_module_opts(
+                   subscription: "projects/foo/subscriptions/bar",
+                   on_success: action
+                 )
+
+        assert producer_opts[:on_success] == action
       end
-    )
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_success to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: :foo/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_success: :foo
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_success to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: "foo"/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_success: "foo"
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_success to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: 1/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_success: 1
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_success to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: SomeModule/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_success: SomeModule
+                     )
+                   end
+    end
+
+    test ":on_failure should be a valid action" do
+      for action <- [:ack, :noop, {:nack, 0}, {:nack, 100}, {:nack, 600}] do
+        assert {_,
+                [
+                  producer: [
+                    module: {BroadwayCloudPubSub.Producer, producer_opts},
+                    concurrency: 1
+                  ]
+                ]} =
+                 prepare_for_start_module_opts(
+                   subscription: "projects/foo/subscriptions/bar",
+                   on_failure: action
+                 )
+
+        assert producer_opts[:on_failure] == action
+      end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_failure to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: :foo/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_failure: :foo
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_failure to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: "foo"/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_failure: "foo"
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_failure to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: 1/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_failure: 1
+                     )
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/expected :on_failure to be one of :ack, :noop, :nack, or {:nack, integer} where integer is between 0 and 600, got: SomeModule/,
+                   fn ->
+                     prepare_for_start_module_opts(
+                       subscription: "projects/foo/subscriptions/bar",
+                       on_failure: SomeModule
+                     )
+                   end
+    end
+
+    test "custom action :nack casts to {:nack, 0}" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} =
+               prepare_for_start_module_opts(
+                 on_failure: :nack,
+                 on_success: :nack,
+                 subscription: "projects/foo/subscriptions/bar"
+               )
+
+      assert producer_opts[:on_success] == {:nack, 0}
+      assert producer_opts[:on_failure] == {:nack, 0}
+    end
+
+    test ":pool_size is optional with default value twice the producer concurrency" do
+      assert {_,
+              [
+                producer: [
+                  module: {BroadwayCloudPubSub.Producer, producer_opts},
+                  concurrency: 1
+                ]
+              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+
+      assert producer_opts[:pool_size] == 2
+    end
+
+    test "with :client PullClient returns a child_spec for starting a Finch pool" do
+      assert {
+               [
+                 {Finch,
+                  name: BroadwayCloudPubSub.ProducerTest.Forwarder.PullClient,
+                  pools: %{default: [size: 5]}}
+               ],
+               [
+                 producer: [
+                   module: {BroadwayCloudPubSub.Producer, _producer_opts},
+                   concurrency: 1
+                 ]
+               ]
+             } =
+               prepare_for_start_module_opts(
+                 subscription: "projects/foo/subscriptions/bar",
+                 pool_size: 5
+               )
+    end
   end
 
   test "receive messages when the queue has less than the demand" do
     {:ok, message_server} = MessageServer.start_link()
-    name = start_broadway(message_server)
+    {:ok, pid} = start_broadway(message_server)
 
     MessageServer.push_messages(message_server, 1..5)
 
@@ -132,13 +562,13 @@ defmodule BroadwayCloudPubSub.ProducerTest do
       assert_receive {:message_handled, ^msg}
     end
 
-    stop_broadway(name)
+    stop_broadway(pid)
   end
 
   test "keep receiving messages when the queue has more than the demand" do
     {:ok, message_server} = MessageServer.start_link()
     MessageServer.push_messages(message_server, 1..20)
-    name = start_broadway(message_server)
+    {:ok, pid} = start_broadway(message_server)
 
     assert_receive {:messages_received, 10}
 
@@ -160,12 +590,12 @@ defmodule BroadwayCloudPubSub.ProducerTest do
 
     assert_receive {:messages_received, 0}
 
-    stop_broadway(name)
+    stop_broadway(pid)
   end
 
   test "keep trying to receive new messages when the queue is empty" do
     {:ok, message_server} = MessageServer.start_link()
-    name = start_broadway(message_server)
+    {:ok, pid} = start_broadway(message_server)
 
     MessageServer.push_messages(message_server, [13])
     assert_receive {:messages_received, 1}
@@ -179,14 +609,15 @@ defmodule BroadwayCloudPubSub.ProducerTest do
     assert_receive {:message_handled, 14}
     assert_receive {:message_handled, 15}
 
-    stop_broadway(name)
+    stop_broadway(pid)
   end
 
   test "stop trying to receive new messages after start draining" do
     {:ok, message_server} = MessageServer.start_link()
-    name = start_broadway(message_server)
+    broadway_name = new_unique_name()
+    {:ok, pid} = start_broadway(broadway_name, message_server)
 
-    [producer] = Broadway.producer_names(name)
+    [producer] = Broadway.producer_names(broadway_name)
 
     assert_receive {:messages_received, 0}
 
@@ -198,89 +629,91 @@ defmodule BroadwayCloudPubSub.ProducerTest do
 
     refute_receive {:messages_received, _}, 10
 
-    stop_broadway(name)
+    stop_broadway(pid)
   end
 
   test "delete acknowledged messages" do
     {:ok, message_server} = MessageServer.start_link()
-    name = start_broadway(message_server)
+    {:ok, pid} = start_broadway(message_server)
 
     MessageServer.push_messages(message_server, 1..20)
 
     assert_receive {:messages_deleted, 10}
     assert_receive {:messages_deleted, 10}
 
-    stop_broadway(name)
+    stop_broadway(pid)
   end
 
   describe "calling Client.prepare_to_connect/2" do
     test "with default options, pool_size is twice the producers" do
       {:ok, message_server} = MessageServer.start_link()
-      name = start_broadway(message_server, FakePoolClient)
+      broadway_name = new_unique_name()
+      {:ok, pid} = start_broadway(broadway_name, message_server, FakePoolClient)
 
       assert_receive {:pool_started, pool}, 500
       assert_receive {:connection_pool_set, ^pool}, 500
       assert FakePool.pool_size(pool) == 2
 
-      stop_broadway(name)
+      stop_broadway(pid)
     end
 
     test "with user-defined pool_size" do
       {:ok, message_server} = MessageServer.start_link()
-      name = start_broadway(message_server, FakePoolClient, pool_size: 20)
+      broadway_name = new_unique_name()
+      {:ok, pid} = start_broadway(broadway_name, message_server, FakePoolClient, pool_size: 20)
 
       assert_receive {:pool_started, pool}, 500
       assert_receive {:connection_pool_set, ^pool}, 500
       assert FakePool.pool_size(pool) == 20
 
-      stop_broadway(name)
+      stop_broadway(pid)
     end
   end
 
-  defp start_broadway(message_server, client \\ FakeClient, extra_opts \\ []) do
-    producer_opts =
-      Keyword.merge(extra_opts,
+  defp start_broadway(
+         broadway_name \\ new_unique_name(),
+         message_server,
+         client \\ FakeClient,
+         opts \\ []
+       ) do
+    Broadway.start_link(
+      Forwarder,
+      build_broadway_opts(broadway_name, opts,
         client: client,
+        subscription: "projects/my-project/subscriptions/my-subscription",
         receive_interval: 0,
         test_pid: self(),
         message_server: message_server
       )
+    )
+  end
 
-    name = new_unique_name()
-
-    {:ok, _pid} =
-      Broadway.start_link(
-        Forwarder,
-        name: name,
-        context: %{test_pid: self()},
-        producer: [
-          module: {
-            BroadwayCloudPubSub.Producer,
-            producer_opts
-          },
+  defp build_broadway_opts(broadway_name, opts, producer_opts) do
+    [
+      name: broadway_name,
+      context: %{test_pid: self()},
+      producer: [
+        module: {BroadwayCloudPubSub.Producer, Keyword.merge(producer_opts, opts)},
+        concurrency: 1
+      ],
+      processors: [
+        default: [concurrency: 1]
+      ],
+      batchers: [
+        default: [
+          batch_size: 10,
+          batch_timeout: 50,
           concurrency: 1
-        ],
-        processors: [
-          default: [concurrency: 1]
-        ],
-        batchers: [
-          default: [
-            batch_size: 10,
-            batch_timeout: 50,
-            concurrency: 1
-          ]
         ]
-      )
-
-    name
+      ]
+    ]
   end
 
   defp new_unique_name() do
     :"Broadway#{System.unique_integer([:positive, :monotonic])}"
   end
 
-  defp stop_broadway(name) when is_atom(name) do
-    pid = Process.whereis(name)
+  defp stop_broadway(pid) do
     ref = Process.monitor(pid)
     Process.exit(pid, :normal)
 

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -79,161 +79,12 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   end
 
   defp init_with_ack_builder(opts) do
+    # mimics workflow from Producer.prepare_for_start/2
+    ack_ref = opts[:broadway][:name]
+    fill_persistent_term(ack_ref, opts)
+
     {:ok, config} = PullClient.init(opts)
-    {:ok, ack_ref} = Acknowledger.init(PullClient, config, opts)
     {ack_ref, Acknowledger.builder(ack_ref), config}
-  end
-
-  describe "validate init options" do
-    test ":subscription is required" do
-      assert PullClient.init([]) ==
-               {:error, "expected :subscription to be a non empty string, got: nil"}
-
-      assert PullClient.init(subscription: nil) ==
-               {:error, "expected :subscription to be a non empty string, got: nil"}
-    end
-
-    test ":subscription should be a valid subscription name" do
-      assert PullClient.init(subscription: "") ==
-               {:error, "expected :subscription to be a non empty string, got: \"\""}
-
-      assert PullClient.init(subscription: :an_atom) ==
-               {:error, "expected :subscription to be a non empty string, got: :an_atom"}
-
-      assert {:ok, %{subscription: subscription}} =
-               PullClient.init(subscription: "projects/foo/subscriptions/bar")
-
-      assert subscription.projects_id == "foo"
-      assert subscription.subscriptions_id == "bar"
-    end
-
-    test ":return_immediately is nil without default value" do
-      {:ok, result} = PullClient.init(subscription: "projects/foo/subscriptions/bar")
-
-      assert is_nil(result.pull_request.returnImmediately)
-    end
-
-    test ":return immediately should be a boolean" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      {:ok, result} = opts |> Keyword.put(:return_immediately, true) |> PullClient.init()
-      assert result.pull_request.returnImmediately == true
-
-      {:ok, result} = opts |> Keyword.put(:return_immediately, false) |> PullClient.init()
-      assert is_nil(result.pull_request.returnImmediately)
-
-      {:error, message} = opts |> Keyword.put(:return_immediately, "true") |> PullClient.init()
-
-      assert message == "expected :return_immediately to be a boolean value, got: \"true\""
-
-      {:error, message} = opts |> Keyword.put(:return_immediately, 0) |> PullClient.init()
-
-      assert message == "expected :return_immediately to be a boolean value, got: 0"
-
-      {:error, message} = opts |> Keyword.put(:return_immediately, :an_atom) |> PullClient.init()
-
-      assert message == "expected :return_immediately to be a boolean value, got: :an_atom"
-    end
-
-    test ":max_number_of_messages is optional with default value 10" do
-      {:ok, result} = PullClient.init(subscription: "projects/foo/subscriptions/bar")
-
-      assert result.pull_request.maxMessages == 10
-    end
-
-    test ":max_number_of_messages should be a positive integer" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      {:ok, result} = opts |> Keyword.put(:max_number_of_messages, 1) |> PullClient.init()
-      assert result.pull_request.maxMessages == 1
-
-      {:ok, result} = opts |> Keyword.put(:max_number_of_messages, 10) |> PullClient.init()
-      assert result.pull_request.maxMessages == 10
-
-      {:error, message} = opts |> Keyword.put(:max_number_of_messages, 0) |> PullClient.init()
-
-      assert message == "expected :max_number_of_messages to be a positive integer, got: 0"
-
-      {:error, message} =
-        opts |> Keyword.put(:max_number_of_messages, :an_atom) |> PullClient.init()
-
-      assert message == "expected :max_number_of_messages to be a positive integer, got: :an_atom"
-    end
-
-    test ":scope should be a string or tuple" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      {:ok, result} = opts |> Keyword.put(:scope, "https://example.com") |> PullClient.init()
-
-      assert {_, _, ["https://example.com"]} = result.token_generator
-
-      {:error, message} = opts |> Keyword.put(:scope, :an_atom) |> PullClient.init()
-
-      assert message == "expected :scope to be a non empty string or tuple, got: :an_atom"
-
-      {:error, message} = opts |> Keyword.put(:scope, 1) |> PullClient.init()
-
-      assert message == "expected :scope to be a non empty string or tuple, got: 1"
-
-      {:error, message} = opts |> Keyword.put(:scope, {}) |> PullClient.init()
-
-      assert message == "expected :scope to be a non empty string or tuple, got: {}"
-
-      {:ok, result} =
-        opts
-        |> Keyword.put(:scope, {"mail@example.com", "https://example.com"})
-        |> PullClient.init()
-
-      assert {_, _, [{"mail@example.com", "https://example.com"}]} = result.token_generator
-    end
-
-    test ":token_generator defaults to using Goth with default scope" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      {:ok, result} = PullClient.init(opts)
-
-      assert result.token_generator ==
-               {BroadwayCloudPubSub.PipelineOptions, :generate_goth_token,
-                ["https://www.googleapis.com/auth/pubsub"]}
-    end
-
-    test ":token_generator should be a tuple {Mod, Fun, Args}" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      token_generator = {Token, :fetch, []}
-
-      {:ok, result} =
-        opts
-        |> Keyword.put(:token_generator, token_generator)
-        |> PullClient.init()
-
-      assert result.token_generator == token_generator
-
-      {:error, message} =
-        opts
-        |> Keyword.put(:token_generator, {1, 1, 1})
-        |> PullClient.init()
-
-      assert message == "expected :token_generator to be a tuple {Mod, Fun, Args}, got: {1, 1, 1}"
-
-      {:error, message} =
-        opts
-        |> Keyword.put(:token_generator, SomeModule)
-        |> PullClient.init()
-
-      assert message ==
-               "expected :token_generator to be a tuple {Mod, Fun, Args}, got: SomeModule"
-    end
-
-    test ":token_generator supercedes :scope validation" do
-      opts = [subscription: "projects/foo/subscriptions/bar"]
-
-      assert {:ok, _result} =
-               opts
-               |> Keyword.put(:scope, :an_invalid_scope)
-               |> Keyword.put(:token_generator, {__MODULE__, :generate_token, []})
-               |> PullClient.init()
-    end
   end
 
   describe "receive_messages/3" do
@@ -247,8 +98,11 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       %{
         pid: test_pid,
         opts: [
+          # will be injected by Broadway at runtime
+          broadway: [name: :Broadway3],
           base_url: base_url,
           finch_name: finch_name,
+          max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []}
         ]
@@ -285,9 +139,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       opts: base_opts,
       server: server
     } do
-      on_pubsub_request(server, fn _, _ ->
-        {:error, 403, @empty_response}
-      end)
+      on_pubsub_request(server, fn _, _ -> {:error, 403, @empty_response} end)
 
       {:ok, opts} = PullClient.init(base_opts)
 
@@ -325,8 +177,11 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       %{
         pid: test_pid,
         opts: [
+          # will be injected by Broadway at runtime
+          broadway: [name: :Broadway3],
           base_url: base_url,
           finch_name: finch_name,
+          max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []}
         ]
@@ -372,8 +227,11 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       %{
         pid: test_pid,
         opts: [
-          finch_name: finch_name,
+          # will be injected by Broadway at runtime
+          broadway: [name: :Broadway3],
           base_url: base_url,
+          finch_name: finch_name,
+          max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []}
         ]
@@ -453,9 +311,12 @@ defmodule BroadwayCloudPubSub.PullClientTest do
        %{
          pid: test_pid,
          opts: [
+           # will be injected by Broadway at runtime
+           broadway: [name: :Broadway3],
            base_url: base_url,
-           finch_name: finch_name,
            client: PullClient,
+           finch_name: finch_name,
+           max_number_of_messages: 10,
            subscription: "projects/foo/subscriptions/bar",
            token_generator: {__MODULE__, :generate_token, []}
          ]
@@ -577,4 +438,16 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   end
 
   def generate_token, do: {:ok, "token.#{System.os_time(:second)}"}
+
+  defp fill_persistent_term(ack_ref, base_opts) do
+    :persistent_term.put(ack_ref, %{
+      base_url: Keyword.fetch!(base_opts, :base_url),
+      client: PullClient,
+      finch_name: Keyword.fetch!(base_opts, :finch_name),
+      on_failure: base_opts[:on_failure] || :noop,
+      on_success: base_opts[:on_success] || :ack,
+      subscription: "projects/test/subscriptions/test-subscription",
+      token_generator: {__MODULE__, :generate_token, []}
+    })
+  end
 end


### PR DESCRIPTION
This is almost exclusively a maintenance PR to consolidate the pipeline configuration on the Producer. Additionally these changes reduce the number of persistent terms to one (1) per BroadwayCloudPubSub pipeline.