### PR TITLE
Allow custom finch_name for pull client

### DIFF
--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -27,9 +27,9 @@ defmodule BroadwayCloudPubSub.Producer do
     * `:base_url` - Optional. The base URL for the Cloud PubSub services.
       Default is "https://pubsub.googleapis.com".
 
-    * `:finch_name` - Optional. The used name to launch the `Finch` client in the supervision tree.
-      Useful if you are reusing the same module for many `Broadway`s.
-      Default is `YourModule.PullClient`.
+    * `:finch_name` - Optional. The used name to launch the `Finch` client
+      in the supervision tree. Useful if you are reusing the same module for
+      many `Broadway` pipelines. Defaults to `YourModule.PullClient`
 
   ### Custom token generator
 

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -27,6 +27,10 @@ defmodule BroadwayCloudPubSub.Producer do
     * `:base_url` - Optional. The base URL for the Cloud PubSub services.
       Default is "https://pubsub.googleapis.com".
 
+    * `:finch_name` - Optional. The used name to launch the `Finch` client in the supervision tree.
+      Useful if you are reusing the same module for many `Broadway`s.
+      Default is `YourModule.PullClient`.
+
   ### Custom token generator
 
   A custom token generator can be given as a MFArgs tuple.

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -16,7 +16,8 @@ defmodule BroadwayCloudPubSub.PullClient do
     # pool size is calculated in the BCPS Producer and guaranteed to be here
     pool_size = Keyword.fetch!(producer_opts, :pool_size)
 
-    finch_name = Module.concat(name, PullClient)
+    finch_name =
+      Keyword.get_lazy(producer_opts, :finch_name, fn -> Module.concat(name, PullClient) end)
 
     children = [
       {Finch, name: finch_name, pools: %{default: [size: pool_size]}}

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -427,6 +427,14 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       assert pool_spec == {Finch, name: SomePipeline.PullClient, pools: %{default: [size: 2]}}
       assert opts == [finch_name: SomePipeline.PullClient, pool_size: 2]
     end
+
+    test "allows custom finch_name" do
+      {[pool_spec], opts} =
+        PullClient.prepare_to_connect(SomePipeline, finch_name: Foo, pool_size: 2)
+
+      assert pool_spec == {Finch, name: Foo, pools: %{default: [size: 2]}}
+      assert opts == [finch_name: Foo, pool_size: 2]
+    end
   end
 
   describe "integration with BroadwayCloudPubSub.Acknowledger" do


### PR DESCRIPTION
Hello,

If you reuse the same module to create different Broadway using this library it breaks with the following message:

```
** (Mix) Could not start application itinerary_core: YourApp.Application.start(:normal, []) returned an error: shutdown: failed to start child: YourApp.Supervisor
    ** (EXIT) shutdown: failed to start child: YourApp.Subscriber
        ** (EXIT) an exception was raised:
            ** (MatchError) no match of right hand side value: {:error, {:shutdown, {:failed_to_start_child, Finch, {:already_started, #PID<0.1195.0>}}}}
                (broadway 1.0.1) lib/broadway/topology.ex:58: Broadway.Topology.init/1
                (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
                (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
                (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

With this PR you can customize the name of the Finch client for each instance avoiding the error.