### PR TITLE
Back-port receive_timeout_option

### DIFF
--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -46,6 +46,9 @@ defmodule BroadwayCloudPubSub.Producer do
     * `:middleware` - Optional. List of custom Tesla middleware
       Example: `[{Tesla.Middleware.BaseUrl, "https://example.com"}]`
 
+    * `:receive_timeout` - Optional. The maximum time to wait for a response before
+      the pull client returns an error. Defaults to `:infinity`.
+
   ### Custom token generator
 
   A custom token generator can be given as a MFArgs tuple.

--- a/test/broadway_cloud_pub_sub/google_api_client_test.exs
+++ b/test/broadway_cloud_pub_sub/google_api_client_test.exs
@@ -211,6 +211,33 @@ defmodule BroadwayCloudPubSub.GoogleApiClientTest do
                |> Keyword.put(:token_generator, {__MODULE__, :generate_token, []})
                |> GoogleApiClient.init()
     end
+
+    test ":receive_timeout is optional with default value :infinity" do
+      {:ok, result} = GoogleApiClient.init(subscription: "projects/foo/subscriptions/bar")
+
+      assert result.receive_timeout == :infinity
+    end
+
+    test ":receive_timeout should be a non-negative integer or :infinity" do
+      opts = [subscription: "projects/foo/subscriptions/bar"]
+
+      {:ok, result} = opts |> Keyword.put(:receive_timeout, 0) |> GoogleApiClient.init()
+      assert result.receive_timeout == 0
+
+      {:ok, result} = opts |> Keyword.put(:receive_timeout, :infinity) |> GoogleApiClient.init()
+      assert result.receive_timeout == :infinity
+
+      {:error, message} = opts |> Keyword.put(:receive_timeout, -1) |> GoogleApiClient.init()
+
+      assert message ==
+               "expected :receive_timeout to be a non-negative integer or :infinity, got: -1"
+
+      {:error, message} =
+        opts |> Keyword.put(:receive_timeout, :an_atom) |> GoogleApiClient.init()
+
+      assert message ==
+               "expected :receive_timeout to be a non-negative integer or :infinity, got: :an_atom"
+    end
   end
 
   describe "receive_messages/3" do


### PR DESCRIPTION
Back-porting https://github.com/dashbitco/broadway_cloud_pub_sub/pull/76 to version 0.7.0.

I think a new 0.7.0 branch would have to be made on your repo so this can be merged into it. But please let me know if I'm misunderstanding.

Btw, thank you for accepting this. Even if it's not put in a release it's a big help.