### PR TITLE
Support user-defined Finch pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `:deliveryAttempt` field to metadata
 
+- Add `:finch` producer option for a user-defined HTTP pool
+
+### Removed
+
+- The `:pool_size` option has been removed. Define your own [Finch][finch]
+  pool and use the `:finch` option instead.
+
+  For example, if your `:pool_size` was 10, then add Finch to your application
+  supervision tree (usually located in `lib/my_app/application.ex`):
+
+  ```elixir
+  children =
+    [
+      {Finch, name: MyFinch, pools: %{:default => [size: 10]}}
+    ]
+  ```
+
+  ...and wherever you invoke `Broadway.start_link/2`, replace this:
+
+  ```elixir
+  producer: [
+    module:
+      {BroadwayCloudPubSub.Producer,
+       subscription: "projects/<your-project-id>/subscriptions/<your-subscription-id>",
+       pool_size: 10}
+  ]
+  ```
+
+  ...with this:
+
+  ```elixir
+  producer: [
+    module:
+      {BroadwayCloudPubSub.Producer,
+       subscription: "projects/<your-project-id>/subscriptions/<your-subscription-id>",
+       finch: MyFinch}
+  ]
+  ```
+
 ## [0.7.1] - 2022-05-09
 
 ### Added
@@ -139,3 +178,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/dashbitco/broadway_cloud_pub_sub/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/dashbitco/broadway_cloud_pub_sub/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/dashbitco/broadway_cloud_pub_sub/releases/tag/v0.1.0
+
+
+[finch]: https://hexdocs.pm/finch

--- a/lib/broadway_cloud_pub_sub/options.ex
+++ b/lib/broadway_cloud_pub_sub/options.ex
@@ -106,7 +106,7 @@ defmodule BroadwayCloudPubSub.Options do
       This option is mostly useful for testing via the Pub/Sub emulator.
       """
     ],
-    finch_name: [
+    finch: [
       type: :atom,
       default: nil,
       doc: """

--- a/lib/broadway_cloud_pub_sub/options.ex
+++ b/lib/broadway_cloud_pub_sub/options.ex
@@ -12,8 +12,6 @@ defmodule BroadwayCloudPubSub.Options do
   @default_scope "https://www.googleapis.com/auth/pubsub"
 
   definition = [
-    # Internal.
-    finch_name: [type: :atom, doc: false],
     # Handled by Broadway.
     broadway: [type: :any, doc: false],
     client: [
@@ -108,11 +106,12 @@ defmodule BroadwayCloudPubSub.Options do
       This option is mostly useful for testing via the Pub/Sub emulator.
       """
     ],
-    pool_size: [
-      type: :pos_integer,
+    finch_name: [
+      type: :atom,
+      default: nil,
       doc: """
-      The size of the connection pool.
-      The default value is twice the producer concurrency.
+      The name of the `Finch` pool. If no name is provided, then a default
+      pool will be started by the pipeline's supervisor.
       """
     ],
     return_immediately: [
@@ -127,6 +126,10 @@ defmodule BroadwayCloudPubSub.Options do
     ],
     message_server: [
       type: :pid,
+      doc: false
+    ],
+    prepare_to_connect_ref: [
+      type: :any,
       doc: false
     ]
   ]

--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -18,11 +18,6 @@ defmodule BroadwayCloudPubSub.Producer do
 
   #{NimbleOptions.docs(BroadwayCloudPubSub.Options.definition())}
 
-    * `:finch_name` - Optional. The name used to launch the `Finch` pool
-      in the supervision tree. Useful if you are reusing the same module for
-      many `Broadway` pipelines. Defaults to a module named `PullClient` in
-      your topology's namespace.
-
   ### Custom token generator
 
   A custom token generator can be given as a MFArgs tuple.
@@ -135,11 +130,6 @@ defmodule BroadwayCloudPubSub.Producer do
   @impl Producer
   def prepare_for_start(_module, broadway_opts) do
     {producer_module, client_opts} = broadway_opts[:producer][:module]
-
-    client_opts =
-      Keyword.put_new_lazy(client_opts, :pool_size, fn ->
-        2 * broadway_opts[:producer][:concurrency]
-      end)
 
     opts = NimbleOptions.validate!(client_opts, Options.definition())
 

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -25,7 +25,7 @@ defmodule BroadwayCloudPubSub.PullClient do
   end
 
   defp prepare_finch(name, producer_opts) do
-    finch = Module.concat(name, PullClient)
+    finch = Module.concat(name, __MODULE__)
 
     specs = [
       {Finch, name: finch}

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -12,7 +12,7 @@ defmodule BroadwayCloudPubSub.PullClient do
 
   @impl Client
   def prepare_to_connect(name, producer_opts) do
-    case Keyword.fetch(producer_opts, :finch_name) do
+    case Keyword.fetch(producer_opts, :finch) do
       {:ok, nil} ->
         prepare_finch(name, producer_opts)
 
@@ -25,13 +25,13 @@ defmodule BroadwayCloudPubSub.PullClient do
   end
 
   defp prepare_finch(name, producer_opts) do
-    finch_name = Module.concat(name, PullClient)
+    finch = Module.concat(name, PullClient)
 
     specs = [
-      {Finch, name: finch_name}
+      {Finch, name: finch}
     ]
 
-    producer_opts = Keyword.put(producer_opts, :finch_name, finch_name)
+    producer_opts = Keyword.put(producer_opts, :finch, finch)
 
     {specs, producer_opts}
   end
@@ -169,7 +169,7 @@ defmodule BroadwayCloudPubSub.PullClient do
     body = Jason.encode!(payload)
     headers = headers(config)
 
-    case finch_request(config.finch_name, url, body, headers, config.receive_timeout) do
+    case finch_request(config.finch, url, body, headers, config.receive_timeout) do
       {:ok, %Response{status: 200, body: body}} ->
         {:ok, Jason.decode!(body)}
 
@@ -181,10 +181,10 @@ defmodule BroadwayCloudPubSub.PullClient do
     end
   end
 
-  defp finch_request(finch_name, url, body, headers, timeout) do
+  defp finch_request(finch, url, body, headers, timeout) do
     :post
     |> Finch.build(url, headers, body)
-    |> Finch.request(finch_name, receive_timeout: timeout)
+    |> Finch.request(finch, receive_timeout: timeout)
   end
 
   defp get_token(%{token_generator: {m, f, a}}) do

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -592,7 +592,7 @@ defmodule BroadwayCloudPubSub.ProducerTest do
     test "with :client PullClient returns a child_spec for starting a Finch pool" do
       assert {
                [
-                 {Finch, name: BroadwayCloudPubSub.ProducerTest.PullClient}
+                 {Finch, name: BroadwayCloudPubSub.ProducerTest.BroadwayCloudPubSub.PullClient}
                ],
                [
                  producer: [

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -80,46 +80,32 @@ defmodule BroadwayCloudPubSub.ProducerTest do
     end
   end
 
-  defmodule FakePool do
-    use GenServer
-
-    def start_link(opts) do
-      GenServer.start_link(__MODULE__, opts, name: opts[:name])
-    end
-
-    def init(opts) do
-      send(opts[:test_pid], {:pool_started, opts[:name]})
-
-      {:ok, opts}
-    end
-
-    def child_spec(name, opts) do
-      {__MODULE__, Keyword.put(opts, :name, name)}
-    end
-
-    def pool_size(pool), do: GenServer.call(pool, :pool_size)
-
-    def handle_call(:pool_size, _, opts) do
-      {:reply, opts[:pool_size], opts}
-    end
-  end
-
-  defmodule FakePoolClient do
+  defmodule FakePrepareToConnectClient do
     alias BroadwayCloudPubSub.Client
 
     @behaviour Client
 
     @impl Client
-    def prepare_to_connect(module, opts) do
-      pool = Module.concat(module, FakePool)
-      pool_spec = FakePool.child_spec(pool, opts)
+    def prepare_to_connect(_module, opts) do
+      ref =
+        opts[:prepare_to_connect_ref] ||
+          raise "expected :prepare_to_connect_ref option to be set, but it was not"
 
-      {[pool_spec], Keyword.put(opts, :__connection_pool__, pool)}
+      test_pid = opts[:test_pid]
+
+      task =
+        {Task,
+         fn ->
+           send(test_pid, {:prepare_to_connect_spec, ref})
+           Process.sleep(:infinity)
+         end}
+
+      {[task], Keyword.put(opts, :prepare_to_connect_ref, ref)}
     end
 
     @impl Client
     def init(opts) do
-      send(opts[:test_pid], {:connection_pool_set, opts[:__connection_pool__]})
+      send(opts[:test_pid], {:prepare_to_connect_opts, opts[:prepare_to_connect_ref]})
 
       {:ok, opts}
     end
@@ -162,7 +148,7 @@ defmodule BroadwayCloudPubSub.ProducerTest do
     test ":subcription should be a string" do
       assert_raise(
         ValidationError,
-        "required option :subscription not found, received options: [:client, :pool_size]",
+        "required option :subscription not found, received options: [:client]",
         fn ->
           prepare_for_start_module_opts([])
         end
@@ -603,24 +589,10 @@ defmodule BroadwayCloudPubSub.ProducerTest do
       assert producer_opts[:on_failure] == {:nack, 0}
     end
 
-    test ":pool_size is optional with default value twice the producer concurrency" do
-      assert {_,
-              [
-                producer: [
-                  module: {BroadwayCloudPubSub.Producer, producer_opts},
-                  concurrency: 1
-                ],
-                name: __MODULE__
-              ]} = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
-
-      assert producer_opts[:pool_size] == 2
-    end
-
     test "with :client PullClient returns a child_spec for starting a Finch pool" do
       assert {
                [
-                 {Finch,
-                  name: BroadwayCloudPubSub.ProducerTest.PullClient, pools: %{default: [size: 5]}}
+                 {Finch, name: BroadwayCloudPubSub.ProducerTest.PullClient}
                ],
                [
                  producer: [
@@ -629,11 +601,26 @@ defmodule BroadwayCloudPubSub.ProducerTest do
                  ],
                  name: __MODULE__
                ]
+             } = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
+    end
+
+    test "with :client PullClient and :finch_name returns empty specs" do
+      assert {
+               [],
+               [
+                 producer: [
+                   module: {BroadwayCloudPubSub.Producer, producer_opts},
+                   concurrency: 1
+                 ],
+                 name: __MODULE__
+               ]
              } =
                prepare_for_start_module_opts(
                  subscription: "projects/foo/subscriptions/bar",
-                 pool_size: 5
+                 finch_name: MyFinch
                )
+
+      assert producer_opts[:finch_name] == MyFinch
     end
   end
 
@@ -726,26 +713,18 @@ defmodule BroadwayCloudPubSub.ProducerTest do
   end
 
   describe "calling Client.prepare_to_connect/2" do
-    test "with default options, pool_size is twice the producers" do
+    test "with default options" do
       {:ok, message_server} = MessageServer.start_link()
       broadway_name = new_unique_name()
-      {:ok, pid} = start_broadway(broadway_name, message_server, FakePoolClient)
+      ref = make_ref()
 
-      assert_receive {:pool_started, pool}, 500
-      assert_receive {:connection_pool_set, ^pool}, 500
-      assert FakePool.pool_size(pool) == 2
+      {:ok, pid} =
+        start_broadway(broadway_name, message_server, FakePrepareToConnectClient,
+          prepare_to_connect_ref: ref
+        )
 
-      stop_broadway(pid)
-    end
-
-    test "with user-defined pool_size" do
-      {:ok, message_server} = MessageServer.start_link()
-      broadway_name = new_unique_name()
-      {:ok, pid} = start_broadway(broadway_name, message_server, FakePoolClient, pool_size: 20)
-
-      assert_receive {:pool_started, pool}, 500
-      assert_receive {:connection_pool_set, ^pool}, 500
-      assert FakePool.pool_size(pool) == 20
+      assert_receive {:prepare_to_connect_spec, ^ref}, 500
+      assert_receive {:prepare_to_connect_opts, ^ref}, 500
 
       stop_broadway(pid)
     end
@@ -754,10 +733,10 @@ defmodule BroadwayCloudPubSub.ProducerTest do
   test "support multiple topologies" do
     {:ok, message_server} = MessageServer.start_link()
     broadway_name = new_unique_name()
-    {:ok, pid_1} = start_broadway(broadway_name, message_server, FakePoolClient, pool_size: 20)
+    {:ok, pid_1} = start_broadway(broadway_name, message_server, FakeClient)
     {:ok, message_server} = MessageServer.start_link()
     broadway_name = new_unique_name()
-    {:ok, pid_2} = start_broadway(broadway_name, message_server, FakePoolClient, pool_size: 20)
+    {:ok, pid_2} = start_broadway(broadway_name, message_server, FakeClient)
 
     stop_broadway(pid_1)
     stop_broadway(pid_2)

--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -604,7 +604,7 @@ defmodule BroadwayCloudPubSub.ProducerTest do
              } = prepare_for_start_module_opts(subscription: "projects/foo/subscriptions/bar")
     end
 
-    test "with :client PullClient and :finch_name returns empty specs" do
+    test "with :client PullClient and :finch returns empty specs" do
       assert {
                [],
                [
@@ -617,10 +617,10 @@ defmodule BroadwayCloudPubSub.ProducerTest do
              } =
                prepare_for_start_module_opts(
                  subscription: "projects/foo/subscriptions/bar",
-                 finch_name: MyFinch
+                 finch: MyFinch
                )
 
-      assert producer_opts[:finch_name] == MyFinch
+      assert producer_opts[:finch] == MyFinch
     end
   end
 

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -66,10 +66,10 @@ defmodule BroadwayCloudPubSub.PullClientTest do
     server = Bypass.open()
     base_url = "http://localhost:#{server.port}"
 
-    finch_name = __MODULE__.FinchName
-    _ = start_supervised({Finch, name: finch_name})
+    finch = __MODULE__.Finch
+    _ = start_supervised({Finch, name: finch})
 
-    {:ok, server: server, base_url: base_url, finch_name: finch_name}
+    {:ok, server: server, base_url: base_url, finch: finch}
   end
 
   def on_pubsub_request(server, fun) when is_function(fun, 2) do
@@ -100,7 +100,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   end
 
   describe "receive_messages/3" do
-    setup %{server: server, base_url: base_url, finch_name: finch_name} do
+    setup %{server: server, base_url: base_url, finch: finch} do
       test_pid = self()
 
       on_pubsub_request(server, fn _url, _body ->
@@ -113,7 +113,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
           # will be injected by Broadway at runtime
           broadway: [name: :Broadway3],
           base_url: base_url,
-          finch_name: finch_name,
+          finch: finch,
           max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []},
@@ -199,7 +199,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   end
 
   describe "acknowledge/2" do
-    setup %{server: server, base_url: base_url, finch_name: finch_name} do
+    setup %{server: server, base_url: base_url, finch: finch} do
       test_pid = self()
 
       on_pubsub_request(server, fn _, _ ->
@@ -212,7 +212,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
           # will be injected by Broadway at runtime
           broadway: [name: :Broadway3],
           base_url: base_url,
-          finch_name: finch_name,
+          finch: finch,
           max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []},
@@ -250,7 +250,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   end
 
   describe "put_deadline/3" do
-    setup %{server: server, base_url: base_url, finch_name: finch_name} do
+    setup %{server: server, base_url: base_url, finch: finch} do
       test_pid = self()
 
       on_pubsub_request(server, fn _, _ ->
@@ -263,7 +263,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
           # will be injected by Broadway at runtime
           broadway: [name: :Broadway3],
           base_url: base_url,
-          finch_name: finch_name,
+          finch: finch,
           max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []},
@@ -304,19 +304,19 @@ defmodule BroadwayCloudPubSub.PullClientTest do
     test "returns a child_spec for starting a Finch http pool " do
       {[pool_spec], opts} = PullClient.prepare_to_connect(SomePipeline, [])
       assert pool_spec == {Finch, name: SomePipeline.PullClient}
-      assert opts == [finch_name: SomePipeline.PullClient]
+      assert opts == [finch: SomePipeline.PullClient]
     end
 
-    test "allows custom finch_name" do
-      {specs, opts} = PullClient.prepare_to_connect(SomePipeline, finch_name: Foo)
+    test "allows custom finch" do
+      {specs, opts} = PullClient.prepare_to_connect(SomePipeline, finch: Foo)
 
       assert specs == []
-      assert opts == [finch_name: Foo]
+      assert opts == [finch: Foo]
     end
   end
 
   describe "integration with BroadwayCloudPubSub.Acknowledger" do
-    setup %{server: server, base_url: base_url, finch_name: finch_name} do
+    setup %{server: server, base_url: base_url, finch: finch} do
       test_pid = self()
 
       on_pubsub_request(server, fn url, body ->
@@ -356,7 +356,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
            broadway: [name: :Broadway3],
            base_url: base_url,
            client: PullClient,
-           finch_name: finch_name,
+           finch: finch,
            max_number_of_messages: 10,
            subscription: "projects/foo/subscriptions/bar",
            token_generator: {__MODULE__, :generate_token, []},
@@ -487,7 +487,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
     :persistent_term.put(ack_ref, %{
       base_url: Keyword.fetch!(base_opts, :base_url),
       client: PullClient,
-      finch_name: Keyword.fetch!(base_opts, :finch_name),
+      finch: Keyword.fetch!(base_opts, :finch),
       on_failure: base_opts[:on_failure] || :noop,
       on_success: base_opts[:on_success] || :ack,
       subscription: "projects/test/subscriptions/test-subscription",

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -303,8 +303,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
   describe "prepare_to_connect/2" do
     test "returns a child_spec for starting a Finch http pool " do
       {[pool_spec], opts} = PullClient.prepare_to_connect(SomePipeline, [])
-      assert pool_spec == {Finch, name: SomePipeline.PullClient}
-      assert opts == [finch: SomePipeline.PullClient]
+      assert pool_spec == {Finch, name: SomePipeline.BroadwayCloudPubSub.PullClient}
+      assert opts == [finch: SomePipeline.BroadwayCloudPubSub.PullClient]
     end
 
     test "allows custom finch" do

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -302,17 +302,16 @@ defmodule BroadwayCloudPubSub.PullClientTest do
 
   describe "prepare_to_connect/2" do
     test "returns a child_spec for starting a Finch http pool " do
-      {[pool_spec], opts} = PullClient.prepare_to_connect(SomePipeline, pool_size: 2)
-      assert pool_spec == {Finch, name: SomePipeline.PullClient, pools: %{default: [size: 2]}}
-      assert opts == [finch_name: SomePipeline.PullClient, pool_size: 2]
+      {[pool_spec], opts} = PullClient.prepare_to_connect(SomePipeline, [])
+      assert pool_spec == {Finch, name: SomePipeline.PullClient}
+      assert opts == [finch_name: SomePipeline.PullClient]
     end
 
     test "allows custom finch_name" do
-      {[pool_spec], opts} =
-        PullClient.prepare_to_connect(SomePipeline, finch_name: Foo, pool_size: 2)
+      {specs, opts} = PullClient.prepare_to_connect(SomePipeline, finch_name: Foo)
 
-      assert pool_spec == {Finch, name: Foo, pools: %{default: [size: 2]}}
-      assert opts == [finch_name: Foo, pool_size: 2]
+      assert specs == []
+      assert opts == [finch_name: Foo]
     end
   end
 


### PR DESCRIPTION
Replaces the `:pool_size` and `:finch_name` options by a single `:finch` option which the user can supply to specify their own Finch pool.