### PR TITLE
Adds telemetry

### DIFF
--- a/lib/broadway_cloud_pub_sub/producer.ex
+++ b/lib/broadway_cloud_pub_sub/producer.ex
@@ -105,6 +105,28 @@ defmodule BroadwayCloudPubSub.Producer do
   The above configuration will set up a producer that continuously receives
   messages from `"projects/my-project/subscriptions/my_subscription"` and sends
   them downstream.
+
+  ## Telemetry
+
+  This producer emits a few [Telemetry](https://github.com/beam-telemetry/telemetry)
+  events which are listed below.
+
+    * `[:broadway_cloud_pub_sub, :pull_client, :pull_request, :start | :stop | :exception]` spans -
+      these events are emitted in "span style" when executing pull requests to GCP PubSub.
+      See `:telemetry.span/3`.
+
+      All these events have the measurements described in `:telemetry.span/3`. The events
+      contain the following metadata:
+
+      * `:requested_messages` - the number of messages requested after applying the `max_messages`
+      config option to the existing demand
+      * `:total_demand` - the total demand accumulated into the producer
+
+    * `[:broadway_cloud_pub_sub, :pull_client, :ack, :start | :stop | :exception]` span - these events
+      are emitted in "span style" when acking messages on GCP PubSub. See `:telemetry.span/3`.
+
+      All these events have the measurements described in `:telemetry.span/3`. The events
+      contain no metadata.
   """
 
   use GenStage
@@ -153,7 +175,9 @@ defmodule BroadwayCloudPubSub.Producer do
 
     {specs, opts} = prepare_to_connect(broadway_opts[:name], client, opts)
 
-    :persistent_term.put(ack_ref, Map.new(opts))
+    ack_opts = Keyword.put(opts, :topology_name, broadway_opts[:name])
+
+    :persistent_term.put(ack_ref, Map.new(ack_opts))
 
     broadway_opts_with_defaults =
       put_in(broadway_opts, [:producer, :module], {producer_module, opts})

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -37,10 +37,10 @@ defmodule BroadwayCloudPubSub.PullClient do
     max_messages = min(demand, config.max_number_of_messages)
 
     :telemetry.span(
-      [:broadway_cloud_pub_sub, :pull_client, :pull_request],
+      [:broadway_cloud_pub_sub, :pull_client, :receive_messages],
       %{
-        requested_messages: max_messages,
-        total_demand: demand,
+        max_messages: max_messages,
+        demand: demand,
         topology_name: config.broadway[:name]
       },
       fn ->
@@ -50,7 +50,8 @@ defmodule BroadwayCloudPubSub.PullClient do
           |> handle_response(:receive_messages)
           |> wrap_received_messages(ack_builder)
 
-        {result, %{topology_name: config.broadway[:name]}}
+        {result,
+         %{topology_name: config.broadway[:name], max_messages: max_messages, demand: demand}}
       end
     )
   end

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -50,8 +50,7 @@ defmodule BroadwayCloudPubSub.PullClient do
           |> handle_response(:receive_messages)
           |> wrap_received_messages(ack_builder)
 
-        {result,
-         %{name: config.broadway[:name], max_messages: max_messages, demand: demand}}
+        {result, %{name: config.broadway[:name], max_messages: max_messages, demand: demand}}
       end
     )
   end

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -41,7 +41,7 @@ defmodule BroadwayCloudPubSub.PullClient do
       %{
         max_messages: max_messages,
         demand: demand,
-        topology_name: config.broadway[:name]
+        name: config.broadway[:name]
       },
       fn ->
         result =
@@ -51,7 +51,7 @@ defmodule BroadwayCloudPubSub.PullClient do
           |> wrap_received_messages(ack_builder)
 
         {result,
-         %{topology_name: config.broadway[:name], max_messages: max_messages, demand: demand}}
+         %{name: config.broadway[:name], max_messages: max_messages, demand: demand}}
       end
     )
   end
@@ -72,14 +72,14 @@ defmodule BroadwayCloudPubSub.PullClient do
   def acknowledge(ack_ids, config) do
     :telemetry.span(
       [:broadway_cloud_pub_sub, :pull_client, :ack],
-      %{topology_name: config.topology_name},
+      %{name: config.topology_name},
       fn ->
         result =
           config
           |> execute(:acknowledge, %{"ackIds" => ack_ids})
           |> handle_response(:acknowledge)
 
-        {result, %{topology_name: config.topology_name}}
+        {result, %{name: config.topology_name}}
       end
     )
   end

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -36,10 +36,23 @@ defmodule BroadwayCloudPubSub.PullClient do
   def receive_messages(demand, ack_builder, config) do
     max_messages = min(demand, config.max_number_of_messages)
 
-    config
-    |> execute(:pull, %{"maxMessages" => max_messages})
-    |> handle_response(:receive_messages)
-    |> wrap_received_messages(ack_builder)
+    :telemetry.span(
+      [:broadway_cloud_pub_sub, :pull_client, :pull_request],
+      %{
+        requested_messages: max_messages,
+        total_demand: demand,
+        topology_name: config.broadway[:name]
+      },
+      fn ->
+        result =
+          config
+          |> execute(:pull, %{"maxMessages" => max_messages})
+          |> handle_response(:receive_messages)
+          |> wrap_received_messages(ack_builder)
+
+        {result, %{topology_name: config.broadway[:name]}}
+      end
+    )
   end
 
   @impl Client
@@ -56,9 +69,18 @@ defmodule BroadwayCloudPubSub.PullClient do
 
   @impl Client
   def acknowledge(ack_ids, config) do
-    config
-    |> execute(:acknowledge, %{"ackIds" => ack_ids})
-    |> handle_response(:acknowledge)
+    :telemetry.span(
+      [:broadway_cloud_pub_sub, :pull_client, :ack],
+      %{topology_name: config.topology_name},
+      fn ->
+        result =
+          config
+          |> execute(:acknowledge, %{"ackIds" => ack_ids})
+          |> handle_response(:acknowledge)
+
+        {result, %{topology_name: config.topology_name}}
+      end
+    )
   end
 
   defp handle_response({:ok, response}, :receive_messages) do

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -305,10 +305,10 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       PullClient.acknowledge(["1", "2", "3"], opts)
 
       assert_received {:start, metadata}
-      assert metadata.topology_name == Broadway3
+      assert metadata.name == Broadway3
       assert_received {:stop, measurements, metadata}
       assert is_integer(measurements.duration)
-      assert metadata.topology_name == Broadway3
+      assert metadata.name == Broadway3
 
       :telemetry.detach(:start_handler)
       :telemetry.detach(:stop_handler)

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -200,7 +200,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
     test "exposes telemetry for pull requests", %{opts: base_opts} do
       :telemetry.attach(
         :start_handler,
-        [:broadway_cloud_pub_sub, :pull_client, :pull_request, :start],
+        [:broadway_cloud_pub_sub, :pull_client, :receive_messages, :start],
         fn _name, _measurements, metadata, _config ->
           send(self(), {:start, metadata})
         end,
@@ -209,7 +209,7 @@ defmodule BroadwayCloudPubSub.PullClientTest do
 
       :telemetry.attach(
         :stop_handler,
-        [:broadway_cloud_pub_sub, :pull_client, :pull_request, :stop],
+        [:broadway_cloud_pub_sub, :pull_client, :receive_messages, :stop],
         fn _name, measurements, _metadata, _config ->
           send(self(), {:stop, measurements})
         end,
@@ -221,8 +221,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
 
       assert_received {:start, metadata}
       assert_received {:stop, measurements}
-      assert metadata.total_demand == 10
-      assert metadata.requested_messages == 5
+      assert metadata.demand == 10
+      assert metadata.max_messages == 5
       assert is_integer(measurements.duration)
 
       :telemetry.detach(:start_handler)

--- a/test/broadway_cloud_pub_sub/pull_client_test.exs
+++ b/test/broadway_cloud_pub_sub/pull_client_test.exs
@@ -196,6 +196,38 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       assert_received {:http_request_called, %{body: body, url: _url}}
       assert body["maxMessages"] == 5
     end
+
+    test "exposes telemetry for pull requests", %{opts: base_opts} do
+      :telemetry.attach(
+        :start_handler,
+        [:broadway_cloud_pub_sub, :pull_client, :pull_request, :start],
+        fn _name, _measurements, metadata, _config ->
+          send(self(), {:start, metadata})
+        end,
+        %{}
+      )
+
+      :telemetry.attach(
+        :stop_handler,
+        [:broadway_cloud_pub_sub, :pull_client, :pull_request, :stop],
+        fn _name, measurements, _metadata, _config ->
+          send(self(), {:stop, measurements})
+        end,
+        %{}
+      )
+
+      {:ok, opts} = base_opts |> Keyword.put(:max_number_of_messages, 5) |> PullClient.init()
+      PullClient.receive_messages(10, & &1, opts)
+
+      assert_received {:start, metadata}
+      assert_received {:stop, measurements}
+      assert metadata.total_demand == 10
+      assert metadata.requested_messages == 5
+      assert is_integer(measurements.duration)
+
+      :telemetry.detach(:start_handler)
+      :telemetry.detach(:stop_handler)
+    end
   end
 
   describe "acknowledge/2" do
@@ -216,7 +248,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
           max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []},
-          receive_timeout: :infinity
+          receive_timeout: :infinity,
+          topology_name: Broadway3
         ]
       }
     end
@@ -247,6 +280,39 @@ defmodule BroadwayCloudPubSub.PullClientTest do
                assert PullClient.acknowledge(["1", "2"], opts) == :ok
              end) =~ "[error] Unable to acknowledge messages with Cloud Pub/Sub - reason: "
     end
+
+    test "emits telemetry events", %{opts: base_opts} do
+      :telemetry.attach(
+        :start_handler,
+        [:broadway_cloud_pub_sub, :pull_client, :ack, :start],
+        fn _name, _measurements, metadata, _config ->
+          send(self(), {:start, metadata})
+        end,
+        %{}
+      )
+
+      :telemetry.attach(
+        :stop_handler,
+        [:broadway_cloud_pub_sub, :pull_client, :ack, :stop],
+        fn _name, measurements, metadata, _config ->
+          send(self(), {:stop, measurements, metadata})
+        end,
+        %{}
+      )
+
+      {:ok, opts} = PullClient.init(base_opts)
+
+      PullClient.acknowledge(["1", "2", "3"], opts)
+
+      assert_received {:start, metadata}
+      assert metadata.topology_name == Broadway3
+      assert_received {:stop, measurements, metadata}
+      assert is_integer(measurements.duration)
+      assert metadata.topology_name == Broadway3
+
+      :telemetry.detach(:start_handler)
+      :telemetry.detach(:stop_handler)
+    end
   end
 
   describe "put_deadline/3" do
@@ -267,7 +333,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
           max_number_of_messages: 10,
           subscription: "projects/foo/subscriptions/bar",
           token_generator: {__MODULE__, :generate_token, []},
-          receive_timeout: :infinity
+          receive_timeout: :infinity,
+          topology_name: Broadway3
         ]
       }
     end
@@ -361,7 +428,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
            max_number_of_messages: 10,
            subscription: "projects/foo/subscriptions/bar",
            token_generator: {__MODULE__, :generate_token, []},
-           receive_timeout: :infinity
+           receive_timeout: :infinity,
+           toplogy_name: Broadway3
          ]
        }}
     end
@@ -493,7 +561,8 @@ defmodule BroadwayCloudPubSub.PullClientTest do
       on_success: base_opts[:on_success] || :ack,
       subscription: "projects/test/subscriptions/test-subscription",
       token_generator: {__MODULE__, :generate_token, []},
-      receive_timeout: base_opts[:receive_timeout] || :infinity
+      receive_timeout: base_opts[:receive_timeout] || :infinity,
+      topology_name: Broadway3
     })
   end
 end


### PR DESCRIPTION
Adds span style events for pull request and ack, including tests and documentation.

Happy to take suggestions on naming. Potentially the existing demand is not something we should emit here? Added it cause it'd find it personally useful but happy to remove if it doesn't make sense.

It was a bit hard to do this because the config passed to ack doesn't come from the same place at all as the config passed to receive_messages, the first being just validated producer opts put in persistent term and not as you'd expect, the ack opts validated in the configure callback. And the second being the full config passed to the producer, including the broadway config. The test config doesn't really match the config when running for real, eg in the tests the `receive_messages` tests get the same config as the `ack` tests