### PR TITLE
Fix typo, subcription -> subscription

### DIFF
--- a/test/broadway_cloud_pub_sub/producer_test.exs
+++ b/test/broadway_cloud_pub_sub/producer_test.exs
@@ -145,7 +145,7 @@ defmodule BroadwayCloudPubSub.ProducerTest do
   end
 
   describe "prepare_for_start/2 validation" do
-    test ":subcription should be a string" do
+    test ":subscription should be a string" do
       assert_raise(
         ValidationError,
         "required option :subscription not found, received options: [:client]",


### PR DESCRIPTION
Found via `codespell -H`