### PR TITLE
Handle messages without data

### DIFF
--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -167,9 +167,7 @@ defmodule BroadwayCloudPubSub.PullClient do
     end
   end
 
-  defp decode_message(%{"data" => nil} = message), do: message
-
-  defp decode_message(%{"data" => encoded_data} = message) do
+  defp decode_message(%{"data" => encoded_data} = message) when is_binary(encoded_data) do
     %{message | "data" => Base.decode64!(encoded_data)}
   end
 

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -173,6 +173,8 @@ defmodule BroadwayCloudPubSub.PullClient do
     %{message | "data" => Base.decode64!(encoded_data)}
   end
 
+  defp decode_message(message), do: message
+
   defp headers(config) do
     token = get_token(config)
     [{"authorization", "Bearer #{token}"}, {"content-type", "application/json"}]

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -171,7 +171,8 @@ defmodule BroadwayCloudPubSub.PullClient do
     %{message | "data" => Base.decode64!(encoded_data)}
   end
 
-  defp decode_message(message), do: message
+  defp decode_message(%{"data" => nil} = message), do: message
+  defp decode_message(%{"attributes" => %{"payloadFormat" => "NONE"}} = message), do: message
 
   defp headers(config) do
     token = get_token(config)


### PR DESCRIPTION
Messages with `payloadFormat: "NONE"` may not contain the data attribute. Note something may have changed on Google's side because I believe this was previously handled by the nil check.

Closes #98