### PR TITLE
Guard against missing data

### DIFF
--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -171,6 +171,7 @@ defmodule BroadwayCloudPubSub.PullClient do
     %{message | "data" => Base.decode64!(encoded_data)}
   end
 
+  defp decode_message(%{"data" => nil} = message), do: message
   defp decode_message(message) when is_map(message) and not is_map_key(message, "data"), do: message
 
   defp headers(config) do

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -172,7 +172,7 @@ defmodule BroadwayCloudPubSub.PullClient do
   end
 
   defp decode_message(%{"data" => nil} = message), do: message
-  defp decode_message(message) when is_map(message) and not is_map_key(message, "data"), do: message
+  defp decode_message(%{} = message) when not is_map_key(message, "data"), do: message
 
   defp headers(config) do
     token = get_token(config)

--- a/lib/broadway_cloud_pub_sub/pull_client.ex
+++ b/lib/broadway_cloud_pub_sub/pull_client.ex
@@ -171,8 +171,7 @@ defmodule BroadwayCloudPubSub.PullClient do
     %{message | "data" => Base.decode64!(encoded_data)}
   end
 
-  defp decode_message(%{"data" => nil} = message), do: message
-  defp decode_message(%{"attributes" => %{"payloadFormat" => "NONE"}} = message), do: message
+  defp decode_message(message) when is_map(message) and not is_map_key(message, "data"), do: message
 
   defp headers(config) do
     token = get_token(config)


### PR DESCRIPTION
Removes the requirement to include `payloadFormat: "NONE"` in a message's attributes when it is missing a `data` field.

Closes https://github.com/dashbitco/broadway_cloud_pub_sub/issues/100